### PR TITLE
Implement MailerLite resubscription workflow with consent renewal

### DIFF
--- a/src/main/kotlin/org/xbery/artbeams/mailing/api/MailingApi.kt
+++ b/src/main/kotlin/org/xbery/artbeams/mailing/api/MailingApi.kt
@@ -17,4 +17,17 @@ interface MailingApi {
     fun subscribeToGroup(email: String, name: String, subscriberGroupId: String, ipAddress: String?): MailerLiteSubscriptionResponse
 
     fun isSubscribedToGroup(email: String, subscriberGroupId: String): Boolean
+
+    /**
+     * Removes subscriber from given subscription group.
+     * Returns true if subscriber was removed successfully, false if subscriber was not in the group.
+     */
+    fun removeFromGroup(email: String, subscriberGroupId: String): Boolean
+
+    /**
+     * Resubscribes user to given subscription group to trigger automation workflow.
+     * If subscriber is already in the group, removes them first and then re-adds them.
+     * This ensures automation workflows are triggered even on resubscription attempts.
+     */
+    fun resubscribeToGroup(email: String, name: String, subscriberGroupId: String, ipAddress: String?): MailerLiteSubscriptionResponse
 }

--- a/src/main/kotlin/org/xbery/artbeams/users/service/UserServiceImpl.kt
+++ b/src/main/kotlin/org/xbery/artbeams/users/service/UserServiceImpl.kt
@@ -107,8 +107,10 @@ class UserServiceImpl(
 
     override fun confirmConsent(userId: String, originProductId: String?) {
         val user = userRepository.requireById(userId)
-        consentService.giveConsent(user.email, ConsentType.NEWS, originProductId)
-        logger.info("Consent confirmed for user ${user.email}")
+        // Use renewConsent to ensure existing consents are revoked and a fresh consent with current valid_from is created
+        // This is important for resubscription scenarios where we want to update the valid_from timestamp
+        consentService.renewConsent(user.email, ConsentType.NEWS, originProductId)
+        logger.info("Consent confirmed (renewed) for user ${user.email}")
     }
 
     override fun updateUserConsent(userId: String, hasConsent: Boolean, originProductId: String?) {

--- a/src/main/kotlin/org/xbery/artbeams/web/FreeProductController.kt
+++ b/src/main/kotlin/org/xbery/artbeams/web/FreeProductController.kt
@@ -148,8 +148,9 @@ class FreeProductController(
             // Add product to user library
             userProductService.addProductToUserLibrary(user.id, product.id)
 
-            // This triggers sending of the product to the user:
-            mailingApi.subscribeToGroup(user.email, fullNameOpt ?: "", requireNotNull(product.mailingGroupId), request.remoteAddr)
+            // Use resubscribeToGroup to ensure automation workflow is triggered even on resubscription
+            // This removes the subscriber from group if already present, then re-adds them
+            mailingApi.resubscribeToGroup(user.email, fullNameOpt ?: "", requireNotNull(product.mailingGroupId), request.remoteAddr)
 
             // TBD: Update order state to SHIPPED
 


### PR DESCRIPTION
This change ensures that automation workflows in MailerLite are triggered even when users attempt to resubscribe, and that database consents are properly renewed with updated valid_from timestamps.

Changes:
- Add removeFromGroup() and resubscribeToGroup() methods to MailingApi
- Update newsletter confirmation to use resubscribeToGroup and renewConsent
- Update product subscription confirmation to use resubscribeToGroup
- Update confirmConsent() to use renewConsent instead of giveConsent
- This ensures existing consents are revoked and new ones created on resubscription

The resubscribeToGroup() method:
1. Removes subscriber from MailerLite group if already present
2. Waits 500ms for MailerLite to process the removal
3. Re-adds subscriber to the group, triggering automation workflow

Consent renewal:
- Revokes existing valid consents by setting valid_to to current time
- Creates new consent with valid_from set to current time
- Tracks origin product ID for product-based subscriptions

This applies to both:
- Free newsletter subscriptions (NewsSubscriptionService)
- Free product download subscriptions (FreeProductController)