### PR TITLE
Add readonly consents administration with pagination

### DIFF
--- a/src/main/kotlin/org/xbery/artbeams/consents/admin/ConsentAdminController.kt
+++ b/src/main/kotlin/org/xbery/artbeams/consents/admin/ConsentAdminController.kt
@@ -1,0 +1,42 @@
+package org.xbery.artbeams.consents.admin
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.ModelAndView
+import org.xbery.artbeams.common.controller.BaseController
+import org.xbery.artbeams.common.controller.ControllerComponents
+import org.xbery.artbeams.common.overview.Pagination
+import org.xbery.artbeams.consents.domain.ConsentType
+import org.xbery.artbeams.consents.repository.ConsentRepository
+
+/**
+ * Consents administration routes.
+ * @author Radek Beran
+ */
+@Controller
+@RequestMapping("/admin/consents")
+class ConsentAdminController(
+    private val consentRepository: ConsentRepository,
+    private val common: ControllerComponents
+) : BaseController(common) {
+    private val TplBasePath: String = "admin/consents"
+
+    @GetMapping
+    fun list(
+        @RequestParam("offset", defaultValue = "0") offset: Int,
+        @RequestParam("limit", defaultValue = "20") limit: Int,
+        request: HttpServletRequest
+    ): Any {
+        val pagination = Pagination(offset, limit)
+        val resultPage = consentRepository.findAllConsents(pagination)
+        val model = createModel(
+            request,
+            "resultPage" to resultPage,
+            "consentTypes" to ConsentType.entries.map { it.name }
+        )
+        return ModelAndView("$TplBasePath/consentList", model)
+    }
+}

--- a/src/main/kotlin/org/xbery/artbeams/consents/domain/Consent.kt
+++ b/src/main/kotlin/org/xbery/artbeams/consents/domain/Consent.kt
@@ -1,5 +1,6 @@
 package org.xbery.artbeams.consents.domain
 
+import org.xbery.artbeams.common.repository.IdentifiedEntity
 import java.io.Serializable
 import java.time.Instant
 
@@ -10,13 +11,13 @@ import java.time.Instant
  * @author Radek Beran
  */
 data class Consent(
-    val id: String,
+    override val id: String,
     val validFrom: Instant,
     val validTo: Instant,
     val login: String, // Email address
     val consentType: ConsentType,
     val originProductId: String? // Product ID if consent was created by product subscription/download
-) : Serializable {
+) : IdentifiedEntity, Serializable {
 
     /**
      * Checks if this consent is currently valid.

--- a/src/main/kotlin/org/xbery/artbeams/consents/repository/ConsentRepository.kt
+++ b/src/main/kotlin/org/xbery/artbeams/consents/repository/ConsentRepository.kt
@@ -1,13 +1,16 @@
 package org.xbery.artbeams.consents.repository
 
 import org.jooq.DSLContext
+import org.jooq.Field
 import org.jooq.Table
 import org.springframework.stereotype.Repository
 import org.xbery.artbeams.consents.domain.Consent
 import org.xbery.artbeams.consents.domain.ConsentType
 import org.xbery.artbeams.consents.repository.mapper.ConsentMapper
 import org.xbery.artbeams.consents.repository.mapper.ConsentUnmapper
-import org.xbery.artbeams.common.repository.AbstractRecordStorage
+import org.xbery.artbeams.common.overview.Pagination
+import org.xbery.artbeams.common.overview.ResultPage
+import org.xbery.artbeams.common.repository.AbstractMappingRepository
 import org.xbery.artbeams.jooq.schema.tables.records.ConsentsRecord
 import org.xbery.artbeams.jooq.schema.tables.references.CONSENTS
 import java.time.Instant
@@ -19,10 +22,24 @@ import java.time.Instant
 @Repository
 class ConsentRepository(
     override val dsl: DSLContext,
-    val mapper: ConsentMapper,
-    val unmapper: ConsentUnmapper
-) : AbstractRecordStorage<Consent, ConsentsRecord> {
+    override val mapper: ConsentMapper,
+    override val unmapper: ConsentUnmapper
+) : AbstractMappingRepository<Consent, ConsentsRecord>(
+    dsl, mapper, unmapper
+) {
     override val table: Table<ConsentsRecord> = CONSENTS
+    override val idField: Field<String?> = CONSENTS.ID
+
+    /**
+     * Finds all consents with pagination.
+     */
+    fun findAllConsents(pagination: Pagination): ResultPage<Consent> =
+        findByCriteria(
+            null,
+            CONSENTS.VALID_FROM.desc(),
+            pagination,
+            mapper
+        )
 
     /**
      * Finds all consents for a given login (email).

--- a/src/main/resources/templates/admin/consents/consentList.ftl
+++ b/src/main/resources/templates/admin/consents/consentList.ftl
@@ -1,0 +1,30 @@
+<#import "/adminLayout.ftl" as layout>
+<#import "/pagination.ftl" as pagination>
+<@layout.page noUp=true>
+
+<table class="table table-sm admin-table">
+  <thead>
+    <tr>
+      <th scope="col">Login</th>
+      <th scope="col">Valid From</th>
+      <th scope="col">Valid To</th>
+      <th scope="col">Consent Type</th>
+      <th scope="col">Product ID</th>
+    </tr>
+  </thead>
+  <tbody>
+<#list resultPage.records as consent>
+    <tr>
+        <td>${consent.login}</td>
+        <td>${consent.validFrom?string["d.M.yyyy, HH:mm"]}</td>
+        <td>${consent.validTo?string["d.M.yyyy, HH:mm"]}</td>
+        <td>${consent.consentType}</td>
+        <td>${consent.originProductId!"-"}</td>
+    </tr>
+</#list>
+  </tbody>
+</table>
+
+<@pagination.pagination pagination=resultPage.pagination />
+
+</@layout.page>

--- a/src/main/resources/templates/adminLayout.ftl
+++ b/src/main/resources/templates/adminLayout.ftl
@@ -125,6 +125,9 @@
             <li class="nav-item">
               <a class="nav-link" href="/admin/orders">Orders</a>
             </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/admin/consents">Consents</a>
+            </li>
           </ul>
   
           <form class="form-inline my-2 my-lg-0 form-config-reload" action="/admin/config/reload" method="POST">


### PR DESCRIPTION
Implements a new admin interface for viewing user consents with:
- Pagination support (20 records per page)
- Display of login, valid from, valid to, consent type, and product ID
- Readonly view (no create/edit/delete actions)
- Navigation link in admin menu

Changes:
- Updated Consent domain to implement IdentifiedEntity
- Enhanced ConsentRepository to extend AbstractMappingRepository for pagination
- Created ConsentAdminController following existing admin patterns
- Added FreeMarker template with pagination component
- Added Consents link to admin navigation menu