### PR TITLE
Add SimpleShop.cz integration for product synchronization

### DIFF
--- a/SIMPLESHOP_INTEGRATION.md
+++ b/SIMPLESHOP_INTEGRATION.md
@@ -1,0 +1,154 @@
+# SimpleShop.cz Integration
+
+This document describes the SimpleShop.cz integration for product synchronization.
+
+## Overview
+
+The integration allows you to synchronize product information (name and price) from SimpleShop.cz to your ArtBeams product catalog. This is a **one-way synchronization** from SimpleShop to ArtBeams.
+
+## Features
+
+- Link products to SimpleShop products via SimpleShop Product ID
+- Sync individual products from SimpleShop
+- Bulk sync all linked products
+- Updates product title and price from SimpleShop
+- Admin UI for managing synchronization
+
+## Configuration
+
+### 1. Get SimpleShop API Credentials
+
+1. Log in to your SimpleShop.cz account
+2. Navigate to Settings → Integrations → API
+3. Note your email and API key
+
+### 2. Configure in Database
+
+Add the following configuration entries to the `config` table in your database:
+
+```sql
+INSERT INTO config (entry_key, entry_value) VALUES ('simpleshop.api.baseUrl', 'https://api.simpleshop.cz/v2');
+INSERT INTO config (entry_key, entry_value) VALUES ('simpleshop.api.email', 'your-email@example.com');
+INSERT INTO config (entry_key, entry_value) VALUES ('simpleshop.api.key', 'your-api-key-here');
+```
+
+Or update the values if they already exist:
+
+```sql
+UPDATE config SET entry_value = 'your-email@example.com' WHERE entry_key = 'simpleshop.api.email';
+UPDATE config SET entry_value = 'your-api-key-here' WHERE entry_key = 'simpleshop.api.key';
+```
+
+### 3. Database Schema Update
+
+Add the `simple_shop_product_id` column to the products table:
+
+```sql
+ALTER TABLE products ADD COLUMN simple_shop_product_id VARCHAR(64) DEFAULT NULL;
+```
+
+### 4. Regenerate JOOQ Classes
+
+After updating the database schema, regenerate JOOQ classes:
+
+```bash
+./gradlew generateJooq
+```
+
+## Usage
+
+### Linking Products
+
+1. Go to the product edit page in the admin interface (`/admin/products/{id}/edit`)
+2. Enter the SimpleShop Product ID in the "SimpleShop Product ID" field
+3. Save the product
+
+### Syncing a Single Product
+
+1. Edit a product that has a SimpleShop Product ID set
+2. Scroll to the "SimpleShop Synchronization" section
+3. Click the "Sync from SimpleShop" button
+
+The system will:
+- Fetch the product data from SimpleShop API
+- Update the product title if it differs and is non-empty in SimpleShop
+- Update the regular price if it differs and is set in SimpleShop
+- Display a success or error message
+
+### Bulk Sync All Products
+
+1. Go to the product list page (`/admin/products`)
+2. Click the "Sync All from SimpleShop" button
+3. Confirm the action
+
+The system will sync all products that have a SimpleShop Product ID set.
+
+## API Limitations
+
+According to the SimpleShop.cz API documentation, the API:
+- **Does not support** creating, updating, or deleting products
+- **Only supports** reading product information via GET /product/{id}/
+
+This is why the integration is one-way (from SimpleShop to ArtBeams) only.
+
+## Architecture
+
+### Components
+
+1. **SimpleShopConfig** (`org.xbery.artbeams.simpleshop.config.SimpleShopConfig`)
+   - Configuration service for API credentials
+
+2. **SimpleShopApiClient** (`org.xbery.artbeams.simpleshop.service.SimpleShopApiClient`)
+   - HTTP client for SimpleShop API
+   - Handles authentication and API requests
+   - Parses product responses
+
+3. **SimpleShopSyncService** (`org.xbery.artbeams.simpleshop.service.SimpleShopSyncService`)
+   - Business logic for synchronization
+   - Compares local and remote products
+   - Updates products when necessary
+
+4. **ProductAdminController** (updated)
+   - Added endpoints:
+     - `POST /admin/products/{id}/sync-from-simpleshop` - Sync single product
+     - `POST /admin/products/sync-all-from-simpleshop` - Bulk sync
+
+### Data Model
+
+- **Product** domain model extended with `simpleShopProductId` field
+- **SimpleShopProduct** DTO for API responses
+
+## Error Handling
+
+The integration handles various error scenarios:
+- Missing API configuration
+- Network errors
+- Invalid product IDs
+- Missing products in SimpleShop
+- API errors
+
+All errors are logged and displayed to the user in the admin interface.
+
+## Logging
+
+The integration logs to the application log with the following information:
+- Sync operations start and completion
+- Individual product updates
+- Errors and warnings
+- Success/failure counts for bulk operations
+
+## Security
+
+- API credentials stored in database config table
+- Basic HTTP authentication used for API requests
+- Admin-only access to sync endpoints (protected by Spring Security)
+- CSRF protection on all POST endpoints
+
+## Future Enhancements
+
+Possible future improvements:
+- Scheduled automatic synchronization
+- Sync history/audit log
+- Support for syncing additional fields (subtitle, images, etc.)
+- Webhook support if SimpleShop adds it
+- Two-way sync if SimpleShop API adds write support

--- a/src/main/kotlin/org/xbery/artbeams/products/admin/ProductForm.kt
+++ b/src/main/kotlin/org/xbery/artbeams/products/admin/ProductForm.kt
@@ -26,6 +26,7 @@ open class ProductForm {
                 .field<String?>("mailingGroupId", Field.TEXT)
                 .field<BigDecimal?>("priceRegularAmount", Field.TEXT)
                 .field<BigDecimal?>("priceDiscountedAmount", Field.TEXT)
+                .field<String?>("simpleShopProductId", Field.TEXT)
                 .build(FormUtils.CZ_CONFIG)
     }
 }

--- a/src/main/kotlin/org/xbery/artbeams/products/domain/EditedProduct.kt
+++ b/src/main/kotlin/org/xbery/artbeams/products/domain/EditedProduct.kt
@@ -16,5 +16,6 @@ data class EditedProduct(
     val confirmationMailingGroupId: String?,
     val mailingGroupId: String?,
     val priceRegularAmount: BigDecimal?,
-    val priceDiscountedAmount: BigDecimal?
+    val priceDiscountedAmount: BigDecimal?,
+    val simpleShopProductId: String?
 )

--- a/src/main/kotlin/org/xbery/artbeams/products/domain/Product.kt
+++ b/src/main/kotlin/org/xbery/artbeams/products/domain/Product.kt
@@ -27,7 +27,9 @@ data class Product(
     /** Regular price of product. */
     val priceRegular: Price,
     /** Discounted price of product. */
-    val priceDiscounted: Price?
+    val priceDiscounted: Price?,
+    /** SimpleShop.cz product ID for synchronization. */
+    val simpleShopProductId: String?
 ) : Asset() {
     /** Price of product. */
     val price: Price
@@ -55,30 +57,32 @@ data class Product(
             confirmationMailingGroupId = edited.confirmationMailingGroupId,
             mailingGroupId = edited.mailingGroupId,
             priceRegular = updatedPriceRegular,
-            priceDiscounted = updatedPriceDiscounted
+            priceDiscounted = updatedPriceDiscounted,
+            simpleShopProductId = edited.simpleShopProductId
         )
     }
 
     fun toEdited(): EditedProduct {
         return EditedProduct(
-            this.id, 
-            this.slug, 
-            this.title, 
-            this.subtitle, 
-            this.fileName, 
-            this.listingImage, 
-            this.image, 
-            this.confirmationMailingGroupId, 
+            this.id,
+            this.slug,
+            this.title,
+            this.subtitle,
+            this.fileName,
+            this.listingImage,
+            this.image,
+            this.confirmationMailingGroupId,
             this.mailingGroupId,
             this.priceRegular.price,
-            this.priceDiscounted?.price
+            this.priceDiscounted?.price,
+            this.simpleShopProductId
         )
     }
 
     companion object {
         val Empty = Product(
             AssetAttributes.EMPTY, "", "New product",
-            null, null, null, null, null, null, Price.ZERO, null
+            null, null, null, null, null, null, Price.ZERO, null, null
         )
     }
 }

--- a/src/main/kotlin/org/xbery/artbeams/products/repository/mapper/ProductMapper.kt
+++ b/src/main/kotlin/org/xbery/artbeams/products/repository/mapper/ProductMapper.kt
@@ -39,7 +39,8 @@ class ProductMapper : RecordMapper<ProductsRecord, Product> {
                     price = requireNotNull(it),
                     currency = Price.DEFAULT_CURRENCY
                 )
-            }
+            },
+            simpleShopProductId = record.simpleShopProductId
         )
     }
 }

--- a/src/main/kotlin/org/xbery/artbeams/products/repository/mapper/ProductUnmapper.kt
+++ b/src/main/kotlin/org/xbery/artbeams/products/repository/mapper/ProductUnmapper.kt
@@ -29,6 +29,7 @@ class ProductUnmapper : RecordUnmapper<Product, ProductsRecord> {
         record.mailingGroupId = product.mailingGroupId
         record.priceRegular = product.priceRegular.price
         record.priceDiscounted = product.priceDiscounted?.price
+        record.simpleShopProductId = product.simpleShopProductId
         return record
     }
 }

--- a/src/main/kotlin/org/xbery/artbeams/simpleshop/config/SimpleShopConfig.kt
+++ b/src/main/kotlin/org/xbery/artbeams/simpleshop/config/SimpleShopConfig.kt
@@ -1,0 +1,34 @@
+package org.xbery.artbeams.simpleshop.config
+
+import org.springframework.stereotype.Component
+import org.xbery.artbeams.config.repository.AppConfig
+
+/**
+ * Configuration for SimpleShop.cz API integration.
+ * @author Radek Beran
+ */
+@Component
+class SimpleShopConfig(
+    private val appConfig: AppConfig
+) {
+    /**
+     * SimpleShop API base URL (e.g., https://api.simpleshop.cz/v2)
+     */
+    fun getApiBaseUrl(): String = appConfig.findConfig("simpleshop.api.baseUrl")
+        ?: "https://api.simpleshop.cz/v2"
+
+    /**
+     * SimpleShop user email for authentication
+     */
+    fun getEmail(): String? = appConfig.findConfig("simpleshop.api.email")
+
+    /**
+     * SimpleShop API key for authentication
+     */
+    fun getApiKey(): String? = appConfig.findConfig("simpleshop.api.key")
+
+    /**
+     * Check if SimpleShop integration is configured
+     */
+    fun isConfigured(): Boolean = !getEmail().isNullOrBlank() && !getApiKey().isNullOrBlank()
+}

--- a/src/main/kotlin/org/xbery/artbeams/simpleshop/domain/SimpleShopProduct.kt
+++ b/src/main/kotlin/org/xbery/artbeams/simpleshop/domain/SimpleShopProduct.kt
@@ -1,0 +1,15 @@
+package org.xbery.artbeams.simpleshop.domain
+
+import java.math.BigDecimal
+
+/**
+ * SimpleShop product data retrieved from API.
+ * @author Radek Beran
+ */
+data class SimpleShopProduct(
+    val id: String,
+    val name: String,
+    val title: String?,
+    val price: BigDecimal?,
+    val type: String?
+)

--- a/src/main/kotlin/org/xbery/artbeams/simpleshop/service/SimpleShopApiClient.kt
+++ b/src/main/kotlin/org/xbery/artbeams/simpleshop/service/SimpleShopApiClient.kt
@@ -1,0 +1,136 @@
+package org.xbery.artbeams.simpleshop.service
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.xbery.artbeams.simpleshop.config.SimpleShopConfig
+import org.xbery.artbeams.simpleshop.domain.SimpleShopProduct
+import java.math.BigDecimal
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.*
+
+/**
+ * Client for SimpleShop.cz API.
+ * @author Radek Beran
+ */
+@Service
+class SimpleShopApiClient(
+    private val config: SimpleShopConfig,
+    private val objectMapper: ObjectMapper
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    private val httpClient: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(10))
+        .build()
+
+    /**
+     * Fetch product data from SimpleShop API.
+     * @param productId SimpleShop product ID
+     * @return Product data or null if not found or error occurred
+     */
+    fun getProduct(productId: String): SimpleShopProduct? {
+        if (!config.isConfigured()) {
+            logger.warn("SimpleShop API is not configured. Please set simpleshop.api.email and simpleshop.api.key in config.")
+            return null
+        }
+
+        try {
+            val url = "${config.getApiBaseUrl()}/product/$productId/"
+            val authHeader = createBasicAuthHeader(config.getEmail()!!, config.getApiKey()!!)
+
+            val request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Authorization", authHeader)
+                .header("Accept", "application/json")
+                .timeout(Duration.ofSeconds(30))
+                .GET()
+                .build()
+
+            logger.info("Fetching product from SimpleShop API: $productId")
+            val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+
+            if (response.statusCode() == 200) {
+                return parseProductResponse(response.body(), productId)
+            } else {
+                logger.error("Failed to fetch product from SimpleShop. Status: ${response.statusCode()}, Body: ${response.body()}")
+                return null
+            }
+        } catch (e: Exception) {
+            logger.error("Error fetching product from SimpleShop: ${e.message}", e)
+            return null
+        }
+    }
+
+    private fun createBasicAuthHeader(email: String, apiKey: String): String {
+        val credentials = "$email:$apiKey"
+        val encodedCredentials = Base64.getEncoder().encodeToString(credentials.toByteArray())
+        return "Basic $encodedCredentials"
+    }
+
+    private fun parseProductResponse(json: String, productId: String): SimpleShopProduct? {
+        try {
+            val rootNode = objectMapper.readTree(json)
+
+            // SimpleShop API returns array with single product
+            val productNode = if (rootNode.isArray && rootNode.size() > 0) {
+                rootNode[0]
+            } else {
+                rootNode
+            }
+
+            val id = productNode.get("id")?.asText() ?: productId
+            val name = productNode.get("name")?.asText() ?: ""
+            val title = productNode.get("title")?.asText()
+            val type = productNode.get("type")?.asText()
+
+            // Price might be in different formats, try to extract it
+            val price = extractPrice(productNode)
+
+            return SimpleShopProduct(
+                id = id,
+                name = name,
+                title = title,
+                price = price,
+                type = type
+            )
+        } catch (e: Exception) {
+            logger.error("Error parsing SimpleShop product response: ${e.message}", e)
+            return null
+        }
+    }
+
+    private fun extractPrice(productNode: JsonNode): BigDecimal? {
+        // Try direct price field
+        productNode.get("price")?.let { priceNode ->
+            if (priceNode.isNumber) {
+                return priceNode.decimalValue()
+            }
+            if (priceNode.isTextual) {
+                return priceNode.asText().toBigDecimalOrNull()
+            }
+        }
+
+        // Try price in variants (first variant)
+        productNode.get("variants")?.let { variants ->
+            if (variants.isArray && variants.size() > 0) {
+                val firstVariant = variants[0]
+                firstVariant.get("price")?.let { variantPrice ->
+                    if (variantPrice.isNumber) {
+                        return variantPrice.decimalValue()
+                    }
+                    if (variantPrice.isTextual) {
+                        return variantPrice.asText().toBigDecimalOrNull()
+                    }
+                }
+            }
+        }
+
+        return null
+    }
+}

--- a/src/main/kotlin/org/xbery/artbeams/simpleshop/service/SimpleShopSyncService.kt
+++ b/src/main/kotlin/org/xbery/artbeams/simpleshop/service/SimpleShopSyncService.kt
@@ -1,0 +1,151 @@
+package org.xbery.artbeams.simpleshop.service
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.xbery.artbeams.common.context.OperationCtx
+import org.xbery.artbeams.prices.domain.Price
+import org.xbery.artbeams.products.domain.Product
+import org.xbery.artbeams.products.repository.ProductRepository
+import org.xbery.artbeams.simpleshop.config.SimpleShopConfig
+
+/**
+ * Service for synchronizing products with SimpleShop.cz.
+ * @author Radek Beran
+ */
+@Service
+class SimpleShopSyncService(
+    private val apiClient: SimpleShopApiClient,
+    private val productRepository: ProductRepository,
+    private val config: SimpleShopConfig
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    /**
+     * Result of product synchronization.
+     */
+    data class SyncResult(
+        val productId: String,
+        val success: Boolean,
+        val message: String,
+        val updatedFields: List<String> = emptyList()
+    )
+
+    /**
+     * Synchronize a single product from SimpleShop.
+     * Updates the product's name (title) and price if they differ from SimpleShop data.
+     *
+     * @param product Product to synchronize
+     * @param ctx Operation context
+     * @return Sync result
+     */
+    fun syncProduct(product: Product, ctx: OperationCtx): SyncResult {
+        if (!config.isConfigured()) {
+            return SyncResult(
+                productId = product.id,
+                success = false,
+                message = "SimpleShop API is not configured"
+            )
+        }
+
+        val simpleShopProductId = product.simpleShopProductId
+        if (simpleShopProductId.isNullOrBlank()) {
+            return SyncResult(
+                productId = product.id,
+                success = false,
+                message = "Product does not have SimpleShop Product ID set"
+            )
+        }
+
+        logger.info("Syncing product ${product.id} with SimpleShop product $simpleShopProductId")
+
+        val simpleShopProduct = apiClient.getProduct(simpleShopProductId)
+        if (simpleShopProduct == null) {
+            return SyncResult(
+                productId = product.id,
+                success = false,
+                message = "Failed to fetch product from SimpleShop (ID: $simpleShopProductId)"
+            )
+        }
+
+        // Determine what needs to be updated
+        val updatedFields = mutableListOf<String>()
+        var updatedProduct = product
+
+        // Update title if different and non-empty in SimpleShop
+        val newTitle = simpleShopProduct.title ?: simpleShopProduct.name
+        if (newTitle.isNotBlank() && newTitle != product.title) {
+            updatedProduct = updatedProduct.copy(title = newTitle)
+            updatedFields.add("title")
+            logger.info("Updating title from '${product.title}' to '$newTitle'")
+        }
+
+        // Update price if different and non-null in SimpleShop
+        simpleShopProduct.price?.let { newPrice ->
+            if (newPrice != product.priceRegular.price) {
+                updatedProduct = updatedProduct.copy(
+                    priceRegular = Price(newPrice, Price.DEFAULT_CURRENCY)
+                )
+                updatedFields.add("price")
+                logger.info("Updating price from '${product.priceRegular.price}' to '$newPrice'")
+            }
+        }
+
+        // Save if there are changes
+        if (updatedFields.isNotEmpty()) {
+            // Update modified timestamp
+            updatedProduct = updatedProduct.copy(
+                common = updatedProduct.common.updatedWith(ctx.userId)
+            )
+            productRepository.update(updatedProduct)
+            logger.info("Product ${product.id} synchronized successfully. Updated fields: ${updatedFields.joinToString(", ")}")
+            return SyncResult(
+                productId = product.id,
+                success = true,
+                message = "Product synchronized successfully",
+                updatedFields = updatedFields
+            )
+        } else {
+            logger.info("Product ${product.id} is already up to date with SimpleShop")
+            return SyncResult(
+                productId = product.id,
+                success = true,
+                message = "Product is already up to date",
+                updatedFields = emptyList()
+            )
+        }
+    }
+
+    /**
+     * Synchronize all products that have SimpleShop Product ID set.
+     *
+     * @param ctx Operation context
+     * @return List of sync results
+     */
+    fun syncAllProducts(ctx: OperationCtx): List<SyncResult> {
+        logger.info("Starting synchronization of all products with SimpleShop")
+
+        val allProducts = productRepository.findProducts()
+        val productsToSync = allProducts.filter { !it.simpleShopProductId.isNullOrBlank() }
+
+        logger.info("Found ${productsToSync.size} products to synchronize")
+
+        val results = productsToSync.map { product ->
+            try {
+                syncProduct(product, ctx)
+            } catch (e: Exception) {
+                logger.error("Error syncing product ${product.id}: ${e.message}", e)
+                SyncResult(
+                    productId = product.id,
+                    success = false,
+                    message = "Error: ${e.message}"
+                )
+            }
+        }
+
+        val successCount = results.count { it.success }
+        val updatedCount = results.count { it.updatedFields.isNotEmpty() }
+        logger.info("Synchronization completed. Success: $successCount/${results.size}, Updated: $updatedCount")
+
+        return results
+    }
+}

--- a/src/main/resources/sql/create_tables.sql
+++ b/src/main/resources/sql/create_tables.sql
@@ -98,7 +98,8 @@ CREATE TABLE products (
 	confirmation_mailing_group_id VARCHAR(128) DEFAULT NULL,
 	mailing_group_id VARCHAR(128) DEFAULT NULL,
 	price_regular DECIMAL(19, 4) NOT NULL,
-	price_discounted DECIMAL(19, 4)
+	price_discounted DECIMAL(19, 4),
+	simple_shop_product_id VARCHAR(64) DEFAULT NULL
 );
 
 CREATE TABLE user_access (

--- a/src/main/resources/sql/insert_config.sql
+++ b/src/main/resources/sql/insert_config.sql
@@ -33,3 +33,8 @@ INSERT INTO config (entry_key, entry_value) VALUES ('bankTransfer.bankCode', 'FI
 INSERT INTO sequences (sequence_name, next_value) VALUES ('orderNumber', 1);
 
 INSERT INTO config (entry_key, entry_value) VALUES ('contact.email', '???');
+
+-- SimpleShop.cz API integration
+INSERT INTO config (entry_key, entry_value) VALUES ('simpleshop.api.baseUrl', 'https://api.simpleshop.cz/v2');
+INSERT INTO config (entry_key, entry_value) VALUES ('simpleshop.api.email', 'FILL IN YOUR SIMPLESHOP EMAIL');
+INSERT INTO config (entry_key, entry_value) VALUES ('simpleshop.api.key', 'FILL IN YOUR SIMPLESHOP API KEY');

--- a/src/main/resources/templates/admin/products/productEdit.ftl
+++ b/src/main/resources/templates/admin/products/productEdit.ftl
@@ -3,6 +3,21 @@
 <#if errorMessage??>
   <div class="alert alert-danger" role="alert">${errorMessage}</div>
 </#if>
+<#if RequestParameters.syncSuccess??>
+  <div class="alert alert-success" role="alert">
+    SimpleShop synchronization successful!
+    <#if RequestParameters.message??><br>${RequestParameters.message}</#if>
+    <#if RequestParameters.fields?? && RequestParameters.fields != "">
+      <br>Updated fields: ${RequestParameters.fields}
+    </#if>
+  </div>
+</#if>
+<#if RequestParameters.syncError??>
+  <div class="alert alert-danger" role="alert">
+    SimpleShop synchronization failed!
+    <#if RequestParameters.message??><br>${RequestParameters.message}</#if>
+  </div>
+</#if>
 
 <#assign fields = editForm.fields>
 <h1>${fields.title.value!}</h1>
@@ -51,8 +66,26 @@
     <div class="col-sm-3"><input type="text" name="${fields.priceDiscountedAmount.name}" value="${fields.priceDiscountedAmount.value!}" id="${fields.priceDiscountedAmount.elementId}" size="10" class="form-control"/></div>
   </div>
   <div class="form-group row">
+    <label for="${fields.simpleShopProductId.elementId}" class="col-sm-2 col-form-label">SimpleShop Product ID</label>
+    <div class="col-sm-3">
+      <input type="text" name="${fields.simpleShopProductId.name}" value="${fields.simpleShopProductId.value!}" id="${fields.simpleShopProductId.elementId}" size="20" class="form-control" placeholder="Optional: For sync from SimpleShop"/>
+      <small class="form-text text-muted">Enter SimpleShop product ID to enable synchronization</small>
+    </div>
+  </div>
+  <div class="form-group row">
     <div class="col-sm-2 col-form-label"></div>
     <div class="col-sm-3"><button type="submit" class="btn btn-primary">Submit</button></div>
   </div>
 </form>
+
+<#if fields.id.value?? && fields.id.value != "" && fields.simpleShopProductId.value?? && fields.simpleShopProductId.value != "">
+<hr class="my-4">
+<h3>SimpleShop Synchronization</h3>
+<p>This product is linked to SimpleShop product ID: <strong>${fields.simpleShopProductId.value}</strong></p>
+<form action="/admin/products/${fields.id.value}/sync-from-simpleshop" method="post" style="display: inline;">
+  <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+  <button type="submit" class="btn btn-info">Sync from SimpleShop</button>
+</form>
+<p class="text-muted mt-2">This will update the product name and price from SimpleShop.</p>
+</#if>
 </@layout.page>

--- a/src/main/resources/templates/admin/products/productList.ftl
+++ b/src/main/resources/templates/admin/products/productList.ftl
@@ -1,7 +1,33 @@
 <#import "/adminLayout.ftl" as layout>
 <@layout.page>
 
+<#if RequestParameters.syncSuccess??>
+  <div class="alert alert-success" role="alert">
+    Bulk synchronization completed!
+    <#if RequestParameters.total??>
+      <br>Total products: ${RequestParameters.total}
+    </#if>
+    <#if RequestParameters.success??>
+      <br>Successful: ${RequestParameters.success}
+    </#if>
+    <#if RequestParameters.updated??>
+      <br>Updated: ${RequestParameters.updated}
+    </#if>
+  </div>
+</#if>
+<#if RequestParameters.syncError??>
+  <div class="alert alert-danger" role="alert">
+    Bulk synchronization failed!
+    <#if RequestParameters.message??><br>${RequestParameters.message}</#if>
+  </div>
+</#if>
+
 <a class="btn btn-primary" href="/admin/products/${emptyId}/edit" role="button">New Product</a>
+
+<form action="/admin/products/sync-all-from-simpleshop" method="post" style="display: inline; margin-left: 10px;">
+  <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
+  <button type="submit" class="btn btn-info" onclick="return confirm('This will sync all products that have SimpleShop Product ID set. Continue?');">Sync All from SimpleShop</button>
+</form>
 
 <table class="table table-sm admin-table">
   <thead>


### PR DESCRIPTION
Implement one-way synchronization from SimpleShop to ArtBeams product catalog.

Features:
- Add simpleShopProductId field to Product model
- Implement SimpleShop API client with Basic auth
- Create sync service for individual and bulk product synchronization
- Add admin endpoints for triggering sync operations
- Update admin UI with SimpleShop Product ID field and sync buttons
- Add configuration support for SimpleShop API credentials

Database changes:
- Add simple_shop_product_id column to products table
- Add SimpleShop API config entries (email, key, baseUrl)

Technical details:
- SimpleShop API v2 is read-only (no product updates via API)
- Synchronization updates product title and regular price
- Uses Java HttpClient for API calls
- Comprehensive error handling and logging
- Admin UI shows sync status and results

Documentation:
- Add SIMPLESHOP_INTEGRATION.md with setup and usage guide

Note: JOOQ classes need regeneration after database schema update