### PR TITLE
Remove email field from admin user editing forms

### DIFF
--- a/src/main/kotlin/org/xbery/artbeams/users/admin/UserForm.kt
+++ b/src/main/kotlin/org/xbery/artbeams/users/admin/UserForm.kt
@@ -21,7 +21,6 @@ open class UserForm {
                 .field<String>("password2", Field.PASSWORD)
                 .field<String>("firstName", Field.TEXT)
                 .field<String>("lastName", Field.TEXT)
-                .field<String>("email", Field.TEXT)
                 .field<List<String>>("roleIds")
                 .validator(PasswordValidator<EditedUser>())
                 .build(FormUtils.CZ_CONFIG)

--- a/src/main/resources/templates/admin/users/userEdit.ftl
+++ b/src/main/resources/templates/admin/users/userEdit.ftl
@@ -13,7 +13,6 @@
   <@forms.inputText field=fields.login label="Login" size=30 inputDivClass="col-sm-3" labelFix=false />
   <@forms.inputText field=fields.firstName label="First name" required=false size=100 inputDivClass="col-sm-3" labelFix=false />
   <@forms.inputText field=fields.lastName label="Last name" required=false size=100 inputDivClass="col-sm-3" labelFix=false />
-  <@forms.inputText type="email" field=fields.email label="E-mail" required=false size=100 inputDivClass="col-sm-3" labelFix=false />
 
   <h3>New password</h3>
 


### PR DESCRIPTION
Removed the email field from:
- UserForm.kt: Removed email field definition from form mapping
- userEdit.ftl: Removed email input field from admin user edit template

The login field (which also serves as email) is preserved in both forms. The email field remains in the EditedUser domain class for backward compatibility.

Member account editing (myProfile.ftl) already did not have an email field.