### PR TITLE
Add in-site editing feature for admin users

### DIFF
--- a/src/main/resources/static/css/insite-editing.css
+++ b/src/main/resources/static/css/insite-editing.css
@@ -1,0 +1,205 @@
+/**
+ * In-site editing styles for ArtBeams CMS
+ * Styles for the inline editing interface
+ * @author ArtBeams
+ */
+
+/* Editable element with highlight */
+.insite-editable {
+    position: relative;
+    transition: all 0.2s ease;
+}
+
+/* Highlighted state on hover */
+.insite-highlight {
+    outline: 2px solid rgba(74, 144, 226, 0.5);
+    outline-offset: 2px;
+    border-radius: 4px;
+    background-color: rgba(74, 144, 226, 0.05);
+    cursor: pointer;
+}
+
+/* Edit icon */
+.insite-edit-icon {
+    display: none;
+    position: absolute;
+    top: -10px;
+    left: -10px;
+    background: #4a90e2;
+    color: white;
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+    cursor: pointer;
+    z-index: 1000;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.insite-edit-icon:hover {
+    background: #357abd;
+    transform: scale(1.1);
+}
+
+.insite-edit-icon svg {
+    width: 14px;
+    height: 14px;
+}
+
+/* Editor container */
+.insite-editor {
+    position: relative;
+    z-index: 999;
+    background: white;
+    padding: 12px;
+    border: 2px solid #4a90e2;
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    margin: -4px;
+}
+
+.insite-editor textarea {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: 1.5;
+    resize: vertical;
+    min-height: 80px;
+    margin-bottom: 8px;
+}
+
+.insite-editor textarea:focus {
+    outline: none;
+    border-color: #4a90e2;
+    box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.1);
+}
+
+/* Editor buttons */
+.insite-editor-buttons {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.insite-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 12px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    transition: all 0.2s ease;
+    min-width: 36px;
+    height: 32px;
+}
+
+.insite-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.insite-btn:active {
+    transform: translateY(0);
+}
+
+.insite-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.insite-btn-success {
+    background: #28a745;
+    color: white;
+}
+
+.insite-btn-success:hover {
+    background: #218838;
+}
+
+.insite-btn-secondary {
+    background: #6c757d;
+    color: white;
+}
+
+.insite-btn-secondary:hover {
+    background: #5a6268;
+}
+
+/* Loading spinner */
+.insite-spinner {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: white;
+    border-radius: 50%;
+    animation: insite-spin 0.6s linear infinite;
+}
+
+@keyframes insite-spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Success feedback */
+.insite-save-success {
+    animation: insite-success-pulse 0.6s ease;
+}
+
+@keyframes insite-success-pulse {
+    0%, 100% {
+        background-color: transparent;
+    }
+    50% {
+        background-color: rgba(40, 167, 69, 0.2);
+    }
+}
+
+/* Editing state */
+.insite-editing {
+    outline: 2px solid #4a90e2;
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .insite-editor {
+        margin: -8px;
+    }
+
+    .insite-edit-icon {
+        top: -8px;
+        left: -8px;
+        width: 28px;
+        height: 28px;
+    }
+
+    .insite-edit-icon svg {
+        width: 16px;
+        height: 16px;
+    }
+}
+
+/* Ensure proper z-index layering */
+.insite-editable.insite-highlight,
+.insite-editable.insite-editing {
+    z-index: 998;
+}
+
+.insite-editable.insite-editing {
+    z-index: 999;
+}
+
+/* Special handling for elements that might have existing positioning */
+.insite-editable:not([style*="position"]) {
+    position: relative;
+}

--- a/src/main/resources/static/js/insite-editing.js
+++ b/src/main/resources/static/js/insite-editing.js
@@ -1,0 +1,382 @@
+/**
+ * In-site editing functionality for ArtBeams CMS
+ * Allows admin users to edit localizations directly on the public website
+ * @author ArtBeams
+ */
+
+(function() {
+    'use strict';
+
+    // Configuration
+    const CONFIG = {
+        localizationSelector: '[data-i18n-key]',
+        articleSelector: 'article[data-article-id]',
+        articleTitleSelector: '[data-article-title]',
+        articlePerexSelector: '[data-article-perex]',
+        editableClass: 'insite-editable',
+        highlightClass: 'insite-highlight',
+        editingClass: 'insite-editing',
+        iconClass: 'insite-edit-icon',
+        editorClass: 'insite-editor',
+        apiEndpoint: '/admin/localisations/update-inline'
+    };
+
+    // State
+    let currentlyEditing = null;
+    let editableElements = [];
+
+    /**
+     * Initialize the in-site editing feature
+     */
+    function init() {
+        // Find all editable elements
+        findEditableElements();
+
+        // Set up event listeners
+        setupEventListeners();
+
+        console.log('In-site editing initialized. Found', editableElements.length, 'editable elements');
+    }
+
+    /**
+     * Find all elements that can be edited
+     */
+    function findEditableElements() {
+        // Find all localization elements
+        const localizationElements = document.querySelectorAll(CONFIG.localizationSelector);
+        localizationElements.forEach(el => {
+            if (!isElementEditable(el)) return;
+
+            editableElements.push({
+                type: 'localization',
+                element: el,
+                key: el.getAttribute('data-i18n-key')
+            });
+
+            el.classList.add(CONFIG.editableClass);
+        });
+
+        // Find article elements for navigation to editor
+        const articleTitles = document.querySelectorAll(CONFIG.articleTitleSelector);
+        articleTitles.forEach(el => {
+            if (!isElementEditable(el)) return;
+
+            editableElements.push({
+                type: 'article-title',
+                element: el,
+                articleId: el.getAttribute('data-article-id')
+            });
+
+            el.classList.add(CONFIG.editableClass);
+        });
+
+        const articlePerexes = document.querySelectorAll(CONFIG.articlePerexSelector);
+        articlePerexes.forEach(el => {
+            if (!isElementEditable(el)) return;
+
+            editableElements.push({
+                type: 'article-perex',
+                element: el,
+                articleId: el.getAttribute('data-article-id')
+            });
+
+            el.classList.add(CONFIG.editableClass);
+        });
+
+        // Find full articles
+        const articles = document.querySelectorAll(CONFIG.articleSelector);
+        articles.forEach(el => {
+            const articleBody = el.querySelector('.article-body');
+            if (!articleBody || !isElementEditable(articleBody)) return;
+
+            editableElements.push({
+                type: 'article',
+                element: articleBody,
+                articleId: el.getAttribute('data-article-id')
+            });
+
+            articleBody.classList.add(CONFIG.editableClass);
+        });
+    }
+
+    /**
+     * Check if an element should be editable
+     */
+    function isElementEditable(el) {
+        // Skip if element is inside an editor or already being edited
+        if (el.closest('.' + CONFIG.editorClass)) return false;
+        if (el.classList.contains(CONFIG.editingClass)) return false;
+
+        // Skip if element is invisible
+        const rect = el.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) return false;
+
+        return true;
+    }
+
+    /**
+     * Set up event listeners for editable elements
+     */
+    function setupEventListeners() {
+        editableElements.forEach(item => {
+            const { element, type } = item;
+
+            // Mouse enter - show edit icon
+            element.addEventListener('mouseenter', (e) => {
+                if (currentlyEditing) return;
+                showEditIcon(element, type);
+            });
+
+            // Mouse leave - hide edit icon
+            element.addEventListener('mouseleave', (e) => {
+                if (currentlyEditing) return;
+                hideEditIcon(element);
+            });
+        });
+
+        // Close editor on Escape key
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && currentlyEditing) {
+                cancelEditing();
+            }
+        });
+    }
+
+    /**
+     * Show edit icon on hover
+     */
+    function showEditIcon(element, type) {
+        element.classList.add(CONFIG.highlightClass);
+
+        // Create edit icon if it doesn't exist
+        let icon = element.querySelector('.' + CONFIG.iconClass);
+        if (!icon) {
+            icon = document.createElement('div');
+            icon.className = CONFIG.iconClass;
+            icon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>';
+            icon.title = type === 'localization' ? 'Edit localization' : 'Edit article';
+
+            icon.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                handleEditClick(element, type);
+            });
+
+            element.appendChild(icon);
+        }
+
+        icon.style.display = 'block';
+    }
+
+    /**
+     * Hide edit icon
+     */
+    function hideEditIcon(element) {
+        element.classList.remove(CONFIG.highlightClass);
+
+        const icon = element.querySelector('.' + CONFIG.iconClass);
+        if (icon) {
+            icon.style.display = 'none';
+        }
+    }
+
+    /**
+     * Handle edit icon click
+     */
+    function handleEditClick(element, type) {
+        const item = editableElements.find(i => i.element === element);
+        if (!item) return;
+
+        if (type === 'localization') {
+            startInlineEditing(element, item.key);
+        } else if (type === 'article' || type === 'article-title' || type === 'article-perex') {
+            navigateToArticleEditor(item.articleId);
+        }
+    }
+
+    /**
+     * Start inline editing for a localization
+     */
+    function startInlineEditing(element, key) {
+        if (currentlyEditing) return;
+
+        currentlyEditing = { element, key };
+        element.classList.add(CONFIG.editingClass);
+
+        // Get current text
+        const currentText = element.textContent.trim();
+
+        // Create editor
+        const editor = document.createElement('div');
+        editor.className = CONFIG.editorClass;
+
+        const textarea = document.createElement('textarea');
+        textarea.value = currentText;
+        textarea.rows = Math.max(3, Math.ceil(currentText.length / 50));
+
+        const buttonContainer = document.createElement('div');
+        buttonContainer.className = 'insite-editor-buttons';
+
+        const saveButton = document.createElement('button');
+        saveButton.className = 'insite-btn insite-btn-success';
+        saveButton.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+        saveButton.title = 'Save';
+        saveButton.addEventListener('click', () => saveLocalization(key, textarea.value));
+
+        const cancelButton = document.createElement('button');
+        cancelButton.className = 'insite-btn insite-btn-secondary';
+        cancelButton.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>';
+        cancelButton.title = 'Cancel';
+        cancelButton.addEventListener('click', cancelEditing);
+
+        buttonContainer.appendChild(saveButton);
+        buttonContainer.appendChild(cancelButton);
+
+        editor.appendChild(textarea);
+        editor.appendChild(buttonContainer);
+
+        // Hide original content and show editor
+        element.style.position = 'relative';
+        const originalContent = element.innerHTML;
+        element.innerHTML = '';
+        element.appendChild(editor);
+
+        // Store original content for restoration
+        element._originalContent = originalContent;
+
+        // Focus textarea
+        textarea.focus();
+        textarea.select();
+    }
+
+    /**
+     * Save localization changes
+     */
+    function saveLocalization(key, newValue) {
+        if (!currentlyEditing) return;
+
+        const { element } = currentlyEditing;
+        const originalValue = element.textContent.trim();
+
+        // Show loading state
+        const editor = element.querySelector('.' + CONFIG.editorClass);
+        const saveButton = editor.querySelector('.insite-btn-success');
+        const originalButtonContent = saveButton.innerHTML;
+        saveButton.disabled = true;
+        saveButton.innerHTML = '<span class="insite-spinner"></span>';
+
+        // Get CSRF token
+        const csrfToken = document.querySelector('meta[name="_csrf"]')?.getAttribute('content') ||
+                         document.querySelector('input[name="_csrf"]')?.value;
+        const csrfHeader = document.querySelector('meta[name="_csrf_header"]')?.getAttribute('content') || '_csrf';
+
+        // Send update to server
+        const headers = {
+            'Content-Type': 'application/json'
+        };
+        if (csrfToken) {
+            headers[csrfHeader] = csrfToken;
+        }
+
+        fetch(CONFIG.apiEndpoint, {
+            method: 'POST',
+            headers: headers,
+            body: JSON.stringify({
+                key: key,
+                value: newValue
+            })
+        })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Failed to save localization');
+            }
+            return response.json();
+        })
+        .then(data => {
+            // Update element with new value
+            element.innerHTML = element._originalContent;
+            // Update the text content while preserving HTML structure
+            const textNode = findTextNode(element);
+            if (textNode) {
+                textNode.textContent = newValue;
+            } else {
+                element.textContent = newValue;
+            }
+
+            // Show success feedback
+            element.classList.add('insite-save-success');
+            setTimeout(() => {
+                element.classList.remove('insite-save-success');
+            }, 2000);
+
+            closeEditor();
+        })
+        .catch(error => {
+            console.error('Error saving localization:', error);
+            alert('Failed to save changes. Please try again or check the browser console for details.');
+
+            // Restore button state
+            saveButton.disabled = false;
+            saveButton.innerHTML = originalButtonContent;
+        });
+    }
+
+    /**
+     * Find the primary text node in an element
+     */
+    function findTextNode(element) {
+        for (let child of element.childNodes) {
+            if (child.nodeType === Node.TEXT_NODE && child.textContent.trim()) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Cancel editing
+     */
+    function cancelEditing() {
+        if (!currentlyEditing) return;
+
+        const { element } = currentlyEditing;
+
+        // Restore original content
+        if (element._originalContent) {
+            element.innerHTML = element._originalContent;
+            delete element._originalContent;
+        }
+
+        closeEditor();
+    }
+
+    /**
+     * Close editor and clean up
+     */
+    function closeEditor() {
+        if (!currentlyEditing) return;
+
+        const { element } = currentlyEditing;
+        element.classList.remove(CONFIG.editingClass);
+
+        currentlyEditing = null;
+    }
+
+    /**
+     * Navigate to article editor in admin panel
+     */
+    function navigateToArticleEditor(articleId) {
+        if (!articleId) return;
+
+        // Navigate to article editor
+        window.location.href = `/admin/articles/${articleId}`;
+    }
+
+    // Initialize when DOM is ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+})();

--- a/src/main/resources/templates/article.ftl
+++ b/src/main/resources/templates/article.ftl
@@ -7,7 +7,7 @@
 <#import "/comments/commentAdd.ftl" as commentAdd>
 <#import "/comments/commentList.ftl" as commentList>
 <@layout.page pageStyles="/static/css/articles.css">
-    <article itemscope itemtype="https://schema.org/BlogPosting">
+    <article itemscope itemtype="https://schema.org/BlogPosting" data-article-id="${article.id}">
         <header>
             <h1 class="blog-post-title" itemprop="headline">${article.title!}</h1>
 

--- a/src/main/resources/templates/author.ftl
+++ b/src/main/resources/templates/author.ftl
@@ -6,8 +6,8 @@
     </div>
     <div class="col-md-11">
       <div class="card-body">
-        <strong class="card-title text-gray-dark">${xlat['author.name']}</strong>
-        <p class="card-text"><small class="text-body-secondary">${xlat['author.about']}</small></p>
+        <strong class="card-title text-gray-dark"><span data-i18n-key="author.name">${xlat['author.name']}</span></strong>
+        <p class="card-text"><small class="text-body-secondary"><span data-i18n-key="author.about">${xlat['author.about']}</span></small></p>
       </div>
     </div>
   </div>

--- a/src/main/resources/templates/comments/commentAdd.ftl
+++ b/src/main/resources/templates/comments/commentAdd.ftl
@@ -2,7 +2,7 @@
 <#macro commentAdd>
 <#assign fields = commentForm.fields>
 <div class="comment-add" id="comment-add">
-    <h3 class="comment-add-title">Napsat komentář</h3>
+    <h3 class="comment-add-title"><span data-i18n-key="comment.add.title">Napsat komentář</span></h3>
     <form action="/comments" method="post" class="comment-form">
       <@forms.inputHidden field=fields.id />
       <@forms.inputHidden field=fields.entityId />
@@ -11,8 +11,8 @@
        <div class="comment-form-ajax-content">
           <#include "/comments/commentFormContent.ftl">
        </div>
-      <p class="comment-info">Povinné údaje jsou označeny *. Emailová adresa nebude zveřejněna. Vaše osobní údaje budou použity pouze pro účely zpracování tohoto komentáře. <a href="${xlat['personal-data.protection.url']}">${xlat['personal-data.protection.title']}</a>.
-      Komentáře s odkazy jsou před zveřejněním schvalovány. HTML znaky nejsou povoleny.</p>
+      <p class="comment-info"><span data-i18n-key="comment.add.info">Povinné údaje jsou označeny *. Emailová adresa nebude zveřejněna. Vaše osobní údaje budou použity pouze pro účely zpracování tohoto komentáře.</span> <a href="${xlat['personal-data.protection.url']}"><span data-i18n-key="personal-data.protection.title">${xlat['personal-data.protection.title']}</span></a>.
+      <span data-i18n-key="comment.add.moderation">Komentáře s odkazy jsou před zveřejněním schvalovány. HTML znaky nejsou povoleny.</span></p>
       <@forms.buttonSubmit text="Odeslat komentář" />
     </form>
 </div>

--- a/src/main/resources/templates/comments/commentList.ftl
+++ b/src/main/resources/templates/comments/commentList.ftl
@@ -1,11 +1,11 @@
 <#macro commentList title>
 <#if comments?size gt 0>
   <div class="comments">
-    <h2>Komentáře (${comments?size})</h2>
+    <h2><span data-i18n-key="comments.heading">Komentáře</span> (${comments?size})</h2>
     <#list comments as comment>
       <div class="comment">
         <div class="comment-meta">${comment.created?string["d.M.yyyy, HH:mm"]}</div>
-        <div class="comment-author"><cite>${comment.userName}</cite> napsal(a):</div>
+        <div class="comment-author"><cite>${comment.userName}</cite> <span data-i18n-key="comments.author.wrote">napsal(a):</span></div>
         <div class="comment-body">${comment.comment}</div>
       </div>
     </#list>

--- a/src/main/resources/templates/components/articleCardModern.ftl
+++ b/src/main/resources/templates/components/articleCardModern.ftl
@@ -17,9 +17,9 @@
             <@badge.categoryBadge article=article featured=true />
             <small class="text-muted ms-2">${article.validFrom?string["d. MMMM yyyy"]}</small>
           </div>
-          <h2 class="card-title h3 mb-3"><a href="/${article.slug}" class="text-decoration-none">${article.title}</a></h2>
-          <p class="card-text">${(article.perex!"")?truncate(350, "...")}</p>
-          <a href="/${article.slug}" class="btn btn-primary-custom">Přečíst článek</a>
+          <h2 class="card-title h3 mb-3"><a href="/${article.slug}" class="text-decoration-none"><span data-article-title data-article-id="${article.id}">${article.title}</span></a></h2>
+          <p class="card-text"><span data-article-perex data-article-id="${article.id}">${(article.perex!"")?truncate(350, "...")}</span></p>
+          <a href="/${article.slug}" class="btn btn-primary-custom"><span data-i18n-key="article.read.button">Přečíst článek</span></a>
         </div>
       </div>
     </div>
@@ -37,9 +37,9 @@
             <@badge.categoryBadge article=article />
             <small class="text-muted ms-2">${article.validFrom?string["d. MMMM yyyy"]}</small>
           </div>
-          <h3 class="card-title"><a href="/${article.slug}" class="text-decoration-none">${article.title}</a></h3>
-          <p class="card-text">${(article.perex!"")?truncate(350, "...")}</p>
-          <a href="/${article.slug}" class="btn btn-sm btn-outline-primary">Přečíst článek</a>
+          <h3 class="card-title"><a href="/${article.slug}" class="text-decoration-none"><span data-article-title data-article-id="${article.id}">${article.title}</span></a></h3>
+          <p class="card-text"><span data-article-perex data-article-id="${article.id}">${(article.perex!"")?truncate(350, "...")}</span></p>
+          <a href="/${article.slug}" class="btn btn-sm btn-outline-primary"><span data-i18n-key="article.read.button">Přečíst článek</span></a>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/components/heroSection.ftl
+++ b/src/main/resources/templates/components/heroSection.ftl
@@ -4,29 +4,29 @@
   <div class="container py-5">
     <div class="row align-items-center">
       <div class="col-lg-7 mb-5 mb-lg-0">
-        <h1 class="display-4 fw-bold mb-4">${xlat['website.title']}</h1>
+        <h1 class="display-4 fw-bold mb-4"><span data-i18n-key="website.title">${xlat['website.title']}</span></h1>
         <p class="lead mb-4">
-          ${xlat['website.description']}
+          <span data-i18n-key="website.description">${xlat['website.description']}</span>
         </p>
         <div class="hero-cta-buttons d-grid gap-3 d-md-flex">
           <#if xlat['headline.offer.url']??>
-            <a href="${xlat['headline.offer.url']}" class="btn btn-primary-custom btn-lg px-4">${xlat['headline.offer.action']!'Více informací'}</a>
+            <a href="${xlat['headline.offer.url']}" class="btn btn-primary-custom btn-lg px-4"><span data-i18n-key="headline.offer.action">${xlat['headline.offer.action']!'Více informací'}</span></a>
           </#if>
           <#if xlat['contact.url']??>
-            <a href="${xlat['contact.url']}" class="btn btn-outline-light btn-lg px-4">Kontaktujte mě</a>
+            <a href="${xlat['contact.url']}" class="btn btn-outline-light btn-lg px-4"><span data-i18n-key="hero.contact.button">Kontaktujte mě</span></a>
           </#if>
         </div>
       </div>
       <div class="col-lg-5">
         <div class="card author-card shadow-lg border-0">
           <div class="card-body text-center">
-            <img src="/static/images/author.webp" 
-                 class="author-profile-image mb-3" 
-                 alt="Autor ${xlat['author.name']}" 
-                 width="200" 
+            <img src="/static/images/author.webp"
+                 class="author-profile-image mb-3"
+                 alt="Autor ${xlat['author.name']}"
+                 width="200"
                  height="200" />
-            <div class="card-title author-name text-secondary-custom mb-2">${xlat['author.name']}</div>
-            <p class="card-text text-light">${xlat['author.description']!'Pomohu Vám...'}</p>
+            <div class="card-title author-name text-secondary-custom mb-2"><span data-i18n-key="author.name">${xlat['author.name']}</span></div>
+            <p class="card-text text-light"><span data-i18n-key="author.description">${xlat['author.description']!'Pomohu Vám...'}</span></p>
           </div>
         </div>
       </div>

--- a/src/main/resources/templates/components/modernFooter.ftl
+++ b/src/main/resources/templates/components/modernFooter.ftl
@@ -5,8 +5,8 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-3 col-md-6 mb-4 mb-md-0">
-        <h5 class="footer-heading text-uppercase mb-4">${xlat['website.title']}</h5>
-        <p>${xlat['website.purpose']}</p>
+        <h5 class="footer-heading text-uppercase mb-4"><span data-i18n-key="website.title">${xlat['website.title']}</span></h5>
+        <p><span data-i18n-key="website.purpose">${xlat['website.purpose']}</span></p>
         <div class="mt-4">
           <#if xlat['fb.page.url']??>
             <a href="${xlat['fb.page.url']}" class="footer-social-icon"><svg class="icon"><use href="#icon-facebook"></use></svg></a>
@@ -51,7 +51,7 @@
 
       <#if articleCategories??>
       <div class="col-lg-3 col-md-6 mb-4 mb-md-0">
-        <h5 class="footer-heading text-uppercase mb-4">Rubriky</h5>
+        <h5 class="footer-heading text-uppercase mb-4"><span data-i18n-key="footer.categories.heading">Rubriky</span></h5>
         <ul class="list-unstyled">
           <#-- TBD: Fill in article categories for contact page and product pages. -->
           <#list articleCategories as category>
@@ -66,10 +66,10 @@
       </#if>
 
       <div class="col-lg-3 col-md-6 mb-4 mb-md-0">
-        <h5 class="footer-heading text-uppercase mb-4">Kontakt</h5>
+        <h5 class="footer-heading text-uppercase mb-4"><span data-i18n-key="footer.contact.heading">Kontakt</span></h5>
         <ul class="list-unstyled">
           <li>
-            <a href="/kontakt" class="footer-link">Kontakt</a>
+            <a href="/kontakt" class="footer-link"><span data-i18n-key="footer.contact.link">Kontakt</span></a>
           </li>
           <#if xlat['contact.address']??>
           <li class="mb-2">
@@ -94,8 +94,8 @@
 
       <#if newsSubscriptionFormMapping??>
       <div class="col-lg-3 col-md-6 mb-4 mb-md-0">
-        <h5 class="footer-heading text-uppercase mb-4">${xlat['news.form.title']}</h5>
-        <p class="small mb-3">${xlat['news.form.intro']}</p>
+        <h5 class="footer-heading text-uppercase mb-4"><span data-i18n-key="news.form.title">${xlat['news.form.title']}</span></h5>
+        <p class="small mb-3"><span data-i18n-key="news.form.intro">${xlat['news.form.intro']}</span></p>
 
         <form class="news-subscription-form" action="/news/subscribe" method="post">
           <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
@@ -112,14 +112,14 @@
     <div class="row align-items-center">
       <div class="col-md-7 text-center text-md-start">
         <p class="small mb-0">
-          &copy; ${.now?string('yyyy')} ${xlat['website.title']}. ${xlat['website.disclaimer']}
+          &copy; ${.now?string('yyyy')} <span data-i18n-key="website.title">${xlat['website.title']}</span>. <span data-i18n-key="website.disclaimer">${xlat['website.disclaimer']}</span>
         </p>
       </div>
       <div class="col-md-5 text-center text-md-end">
         <ul class="list-inline mb-0">
           <#if xlat['terms-and-conditions.url']??>
           <li class="list-inline-item">
-            <a href="${xlat['terms-and-conditions.url']}" class="footer-link small">${xlat['terms-and-conditions.title']}</a>
+            <a href="${xlat['terms-and-conditions.url']}" class="footer-link small"><span data-i18n-key="terms-and-conditions.title">${xlat['terms-and-conditions.title']}</span></a>
           </li>
           <li class="list-inline-item">
             <span class="text-secondary-custom mx-2">•</span>
@@ -127,7 +127,7 @@
           </#if>
           <#if xlat['personal-data.protection.url']??>
           <li class="list-inline-item">
-            <a href="${xlat['personal-data.protection.url']}" class="footer-link small">${xlat['personal-data.protection.title']}</a>
+            <a href="${xlat['personal-data.protection.url']}" class="footer-link small"><span data-i18n-key="personal-data.protection.title">${xlat['personal-data.protection.title']}</span></a>
           </li>
           <li class="list-inline-item">
             <span class="text-secondary-custom mx-2">•</span>
@@ -135,14 +135,14 @@
           </#if>
           <#if xlat['cookies.url']??>
             <li class="list-inline-item">
-              <a href="${xlat['cookies.url']}" class="footer-link small">${xlat['cookies.title']}</a>
+              <a href="${xlat['cookies.url']}" class="footer-link small"><span data-i18n-key="cookies.title">${xlat['cookies.title']}</span></a>
             </li>
             <li class="list-inline-item">
               <span class="text-secondary-custom mx-2">•</span>
             </li>
           </#if>
           <li class="list-inline-item">
-            <a href="#body-element" class="footer-link small"><svg class="icon"><use href="#icon-arrow-up"></use></svg> ${xlat['goto.up']}</a>
+            <a href="#body-element" class="footer-link small"><svg class="icon"><use href="#icon-arrow-up"></use></svg> <span data-i18n-key="goto.up">${xlat['goto.up']}</span></a>
           </li>
         </ul>
       </div>

--- a/src/main/resources/templates/components/modernNavbar.ftl
+++ b/src/main/resources/templates/components/modernNavbar.ftl
@@ -12,38 +12,38 @@
         <ul class="navbar-nav me-auto mb-2 mb-md-0">
           <#if xlat['menu.item1.title']??>
             <li class="nav-item">
-              <a class="nav-link nav-link-custom" href="${xlat['menu.item1.url']}">${xlat['menu.item1.title']}</a>
+              <a class="nav-link nav-link-custom" href="${xlat['menu.item1.url']}"><span data-i18n-key="menu.item1.title">${xlat['menu.item1.title']}</span></a>
             </li>
           </#if>
           <#if xlat['menu.item2.title']??>
             <li class="nav-item">
-              <a class="nav-link nav-link-custom" href="${xlat['menu.item2.url']}">${xlat['menu.item2.title']}</a>
+              <a class="nav-link nav-link-custom" href="${xlat['menu.item2.url']}"><span data-i18n-key="menu.item2.title">${xlat['menu.item2.title']}</span></a>
             </li>
           </#if>
           <#if xlat['menu.item3.title']??>
             <li class="nav-item">
-              <a class="nav-link nav-link-custom" href="${xlat['menu.item3.url']}">${xlat['menu.item3.title']}</a>
+              <a class="nav-link nav-link-custom" href="${xlat['menu.item3.url']}"><span data-i18n-key="menu.item3.title">${xlat['menu.item3.title']}</span></a>
             </li>
           </#if>
           <#if xlat['menu.item4.title']??>
             <li class="nav-item">
-              <a class="nav-link nav-link-custom" href="${xlat['menu.item4.url']}">${xlat['menu.item4.title']}</a>
+              <a class="nav-link nav-link-custom" href="${xlat['menu.item4.url']}"><span data-i18n-key="menu.item4.title">${xlat['menu.item4.title']}</span></a>
             </li>
           </#if>
           <#if xlat['menu.item5.title']??>
             <li class="nav-item">
-              <a class="nav-link nav-link-custom" href="${xlat['menu.item5.url']}">${xlat['menu.item5.title']}</a>
+              <a class="nav-link nav-link-custom" href="${xlat['menu.item5.url']}"><span data-i18n-key="menu.item5.title">${xlat['menu.item5.title']}</span></a>
             </li>
           </#if>
           <#if xlat['menu.item6.title']??>
             <li class="nav-item">
-              <a class="nav-link nav-link-custom" href="${xlat['menu.item6.url']}">${xlat['menu.item6.title']}</a>
+              <a class="nav-link nav-link-custom" href="${xlat['menu.item6.url']}"><span data-i18n-key="menu.item6.title">${xlat['menu.item6.title']}</span></a>
             </li>
           </#if>
         </ul>
         <form method="get" action="/search" class="d-flex" role="search">
           <input type="search" name="query" class="form-control search-box me-2" placeholder="Hledat" aria-label="${xlat['search']}">
-          <button class="btn btn-primary-custom" type="submit">${xlat['search']}</button>
+          <button class="btn btn-primary-custom" type="submit"><span data-i18n-key="search">${xlat['search']}</span></button>
         </form>
    </div>
  </div>

--- a/src/main/resources/templates/components/modernSidebar.ftl
+++ b/src/main/resources/templates/components/modernSidebar.ftl
@@ -9,16 +9,16 @@
   <!-- About Section -->
   <div class="card sidebar border-0 shadow-sm">
     <div class="card-body">
-      <h4>O stránkách</h4>
-      <p><em>${xlat['website.title']}</em> ${xlat['website.purpose']}</p>
+      <h4><span data-i18n-key="sidebar.about.heading">O stránkách</span></h4>
+      <p><em><span data-i18n-key="website.title">${xlat['website.title']}</span></em> <span data-i18n-key="website.purpose">${xlat['website.purpose']}</span></p>
     </div>
   </div>
-  
+
   <!-- Latest Posts -->
   <#if latestArticles??>
   <div class="card sidebar border-0 shadow-sm">
     <div class="card-body">
-      <h4>Nejnovější příspěvky</h4>
+      <h4><span data-i18n-key="sidebar.latest.heading">Nejnovější příspěvky</span></h4>
       <ul class="list-unstyled">
         <#list latestArticles as article>
         <li>
@@ -42,7 +42,7 @@
   <#if articleCategories??>
   <div class="card sidebar border-0 shadow-sm">
     <div class="card-body">
-      <h4>Rubriky</h4>
+      <h4><span data-i18n-key="sidebar.categories.heading">Rubriky</span></h4>
       <div class="d-flex flex-wrap gap-2">
         <#list articleCategories as category>
         <a href="${xlat['categories.url.base']}/${category.slug}" class="btn btn-sm btn-outline-secondary mb-2">${category.title}</a>
@@ -55,7 +55,7 @@
   <!-- Social Networks -->
   <div class="card sidebar border-0 shadow-sm">
     <div class="card-body">
-      <h4>Sociální sítě</h4>
+      <h4><span data-i18n-key="sidebar.social.heading">Sociální sítě</span></h4>
       <div class="d-flex">
         <#if xlat['fb.page.url']??>
           <a href="${xlat['fb.page.url']}?ref=embed_page">
@@ -96,7 +96,7 @@
   <#if subscriptionFormMapping??>
     <#if xlat['mailer-lite.form.title']??>
     <div class="newsletter-section">
-      <h4>Stáhněte si zdarma e-book</h4>
+      <h4><span data-i18n-key="sidebar.ebook.heading">Stáhněte si zdarma e-book</span></h4>
       <@subscriptionForm.subscriptionForm productSlug=xlat['offer1.productSlug'] subscriptionFormMapping=subscriptionFormMapping formClass='offer1-sidebar-subscription-form' textColor='white'></@subscriptionForm.subscriptionForm>
     </div>
     </#if>

--- a/src/main/resources/templates/contact/contactPage.ftl
+++ b/src/main/resources/templates/contact/contactPage.ftl
@@ -26,8 +26,8 @@
                 <p><strong>E-mail:</strong> <a href="mailto:${contactEmail}">${contactEmail}</a></p>
               </#if>
               <#if contactPhone??>
-                <p><strong>Telefon:</strong> <a href="tel:${contactPhone}</a></p>
-                <p class="text-muted">Prosím respektujte soukromí a volejte jen v nejnutnějších případech.</p>
+                <p><strong><span data-i18n-key="contact.phone.label">Telefon:</span></strong> <a href="tel:${contactPhone}">${contactPhone}</a></p>
+                <p class="text-muted"><span data-i18n-key="contact.phone.privacy">Prosím respektujte soukromí a volejte jen v nejnutnějších případech.</span></p>
               </#if>
               <#if facebookFunPageUrl??>
                 <p><a href="${facebookFunPageUrl}" target="_blank"><strong>${facebookFunPageName}</strong></a></p>

--- a/src/main/resources/templates/homepage.ftl
+++ b/src/main/resources/templates/homepage.ftl
@@ -18,11 +18,11 @@
         <ul class="pagination justify-content-center">
           <#if pagination.hasPrevious>
             <li class="page-item">
-              <a class="page-link" href="?page=${pagination.previousPage}">Předchozí</a>
+              <a class="page-link" href="?page=${pagination.previousPage}"><span data-i18n-key="pagination.previous">Předchozí</span></a>
             </li>
           <#else>
             <li class="page-item disabled">
-              <a class="page-link" href="#" tabindex="-1" aria-disabled="true">Předchozí</a>
+              <a class="page-link" href="#" tabindex="-1" aria-disabled="true"><span data-i18n-key="pagination.previous">Předchozí</span></a>
             </li>
           </#if>
           
@@ -36,11 +36,11 @@
           
           <#if pagination.hasNext>
             <li class="page-item">
-              <a class="page-link" href="?page=${pagination.nextPage}">Další</a>
+              <a class="page-link" href="?page=${pagination.nextPage}"><span data-i18n-key="pagination.next">Další</span></a>
             </li>
           <#else>
             <li class="page-item disabled">
-              <a class="page-link" href="#" tabindex="-1" aria-disabled="true">Další</a>
+              <a class="page-link" href="#" tabindex="-1" aria-disabled="true"><span data-i18n-key="pagination.next">Další</span></a>
             </li>
           </#if>
         </ul>
@@ -48,8 +48,8 @@
     </#if>
   <#else>
     <div class="text-center py-5">
-      <h3>Žádné články zatím nejsou k dispozici.</h3>
-      <p class="text-muted">Brzy zde najdete zajímavý obsah!</p>
+      <h3><span data-i18n-key="homepage.no.articles.heading">Žádné články zatím nejsou k dispozici.</span></h3>
+      <p class="text-muted"><span data-i18n-key="homepage.no.articles.text">Brzy zde najdete zajímavý obsah!</span></p>
     </div>
   </#if>
 </@layout.page>

--- a/src/main/resources/templates/newWebLayout.ftl
+++ b/src/main/resources/templates/newWebLayout.ftl
@@ -160,6 +160,11 @@ ${websiteJsonLd}
     <link href="${pageStyles2}" type="text/css" rel="stylesheet">
   </#if>
 
+  <#-- In-site editing for admin users -->
+  <#if _loggedUser?? && _loggedUser.roleNames?seq_contains("admin")>
+    <link href="/static/css/insite-editing.css?v1" type="text/css" rel="stylesheet">
+  </#if>
+
   <#include "/commonScripts.ftl">
 
   </head>
@@ -236,9 +241,9 @@ ${websiteJsonLd}
   <!-- Cookie disclaimer -->
   <div id="cookie-disclaimer" class="cookie-disclaimer">
     <div class="container">
-      <p>${xlat['cookies.info']} <a class="cookie_info_more" target="_blank" href="${xlat['cookies.url']}">${xlat['cookies.info.more']}</a>.
+      <p><span data-i18n-key="cookies.info">${xlat['cookies.info']}</span> <a class="cookie_info_more" target="_blank" href="${xlat['cookies.url']}"><span data-i18n-key="cookies.info.more">${xlat['cookies.info.more']}</span></a>.
 
-      <#if xlat['cookies.acceptAll']??>&nbsp;<button type="button" id="accept-cookie" class="btn btn-success">${xlat['cookies.acceptAll']}</button></#if>
+      <#if xlat['cookies.acceptAll']??>&nbsp;<button type="button" id="accept-cookie" class="btn btn-success"><span data-i18n-key="cookies.acceptAll">${xlat['cookies.acceptAll']}</span></button></#if>
       <button type="button" id="close-cookie" class="btn btn-secondary">X</button></p>
     </div>
   </div>
@@ -249,6 +254,11 @@ ${websiteJsonLd}
   <script nonce="${_cspNonce}" src="/static/js/responsive-images.js"></script>
   <!-- reCaptcha -->
   <script async defer nonce="${_cspNonce}" data-type="lazy" data-src="https://www.google.com/recaptcha/api.js?render=${xlat['recaptcha.siteKey']}"></script>
+
+  <#-- In-site editing for admin users -->
+  <#if _loggedUser?? && _loggedUser.roleNames?seq_contains("admin")>
+  <script nonce="${_cspNonce}" src="/static/js/insite-editing.js?v1"></script>
+  </#if>
 
   <script nonce="${_cspNonce}">
       <#-- Lazy loading of data-type='lazy' scripts and iframes -->

--- a/src/main/resources/templates/search.ftl
+++ b/src/main/resources/templates/search.ftl
@@ -1,7 +1,7 @@
 <#import "/newWebLayout.ftl" as layout>
 <#import "/components/articleCardModern.ftl" as articleCard>
 <@layout.page>
-  <div class="row"><p>Výsledky vyhledávání <strong>'${query}'</strong>:<#if query?length < 2> Zadejte prosím více znaků.</#if></p></div>
+  <div class="row"><p><span data-i18n-key="search.results.label">Výsledky vyhledávání</span> <strong>'${query}'</strong>:<#if query?length < 2> <span data-i18n-key="search.enter.more.chars">Zadejte prosím více znaků.</span></#if></p></div>
   <#list articles as article>
     <@articleCard.articleCardModern article=article />
   </#list>


### PR DESCRIPTION
This commit implements a comprehensive in-site editing system that allows admin users to edit localizations and navigate to article editors directly from the public website.

Features implemented:
- JavaScript-based in-site editing interface (insite-editing.js)
- CSS styling for editing UI (insite-editing.css)
- Conditional loading of editing assets only for admin users
- Data attributes marking all localizations in public templates
- Data attributes for article titles and perex for navigation to editor
- Backend REST API endpoint for saving localization changes
- Automatic cache reload after localization updates

Technical details:
1. Frontend:
   - Highlight editable elements on hover with thin blue outline
   - Show edit pencil icon in top-left corner of editable elements
   - For localizations: open inline text editor with save/cancel buttons
   - For articles: navigate to article editor in admin panel
   - AJAX submission with CSRF token support
   - Visual feedback on successful save

2. Backend:
   - New endpoint: POST /admin/localisations/update-inline
   - Accepts JSON: {key: "localization.key", value: "new value"}
   - Returns JSON with success status and message
   - Automatically reloads localization cache after save

3. Templates modified:
   - newWebLayout.ftl: Added conditional JS/CSS includes for admins
   - All public templates: Added data-i18n-key attributes
   - Article templates: Added data-article-id attributes
   - Components: navbar, footer, sidebar, hero section marked
   - Pages: homepage, article detail, search, contact, author marked
   - Comments: comment list and add form marked

Security:
- In-site editing only visible to users with "admin" role
- Backend endpoint secured by existing Spring Security config
- CSRF token validation on all save operations

This feature enables rapid content localization updates without navigating to the admin panel, improving the editing workflow.