### PR TITLE
Simplify comment link validation with unified pattern matching

### DIFF
--- a/src/main/kotlin/org/xbery/artbeams/comments/controller/CommentValidator.kt
+++ b/src/main/kotlin/org/xbery/artbeams/comments/controller/CommentValidator.kt
@@ -16,28 +16,21 @@ class CommentValidator : AbstractValidator<String>() {
     override fun <U : String> validate(ctx: ValidationContext<U>): List<InterpolatedMessage> {
         val msgs: MutableList<InterpolatedMessage> = mutableListOf()
         val comment = ctx.validatedValue
-        if (comment.isNotEmpty()) {
-            if (containsLink(comment)) {
-                msgs.add(
-                    this.error(
-                        ctx.elementName,
-                        "{constraints.Comment.containsLink.message}",
-                        *arrayOf(Arg("currentValue", ctx.validatedValue as Serializable))
-                    )
+        if (comment.isNotEmpty() &&
+            (
+                containsLink(comment) ||
+                    HtmlUtils.containsHtmlMarkup(comment) ||
+                    containsAtLeastNChars(comment, 15, RU_CHARS) ||
+                    containsStopwords(comment)
+            )
+        ) {
+            msgs.add(
+                this.error(
+                    ctx.elementName,
+                    "{constraints.Comment.message}",
+                    *arrayOf(Arg("currentValue", ctx.validatedValue as Serializable))
                 )
-            } else if (
-                HtmlUtils.containsHtmlMarkup(comment) ||
-                containsAtLeastNChars(comment, 15, RU_CHARS) ||
-                containsStopwords(comment)
-            ) {
-                msgs.add(
-                    this.error(
-                        ctx.elementName,
-                        "{constraints.Comment.message}",
-                        *arrayOf(Arg("currentValue", ctx.validatedValue as Serializable))
-                    )
-                )
-            }
+            )
         }
 
         return msgs

--- a/src/main/kotlin/org/xbery/artbeams/comments/controller/CommentValidator.kt
+++ b/src/main/kotlin/org/xbery/artbeams/comments/controller/CommentValidator.kt
@@ -16,22 +16,28 @@ class CommentValidator : AbstractValidator<String>() {
     override fun <U : String> validate(ctx: ValidationContext<U>): List<InterpolatedMessage> {
         val msgs: MutableList<InterpolatedMessage> = mutableListOf()
         val comment = ctx.validatedValue
-        if (comment.isNotEmpty() &&
-            (
-                HtmlUtils.containsHtmlMarkup(comment) ||
-                    containsAtLeastNChars(comment, 15, RU_CHARS) ||
-                    startsWithLink(comment) ||
-                    containsStopwords(comment) ||
-                    startsOrEndsWithRuLink(comment)
-            )
-        ) {
-            msgs.add(
-                this.error(
-                    ctx.elementName,
-                    "{constraints.Comment.message}",
-                    *arrayOf(Arg("currentValue", ctx.validatedValue as Serializable))
+        if (comment.isNotEmpty()) {
+            if (containsLink(comment)) {
+                msgs.add(
+                    this.error(
+                        ctx.elementName,
+                        "{constraints.Comment.containsLink.message}",
+                        *arrayOf(Arg("currentValue", ctx.validatedValue as Serializable))
+                    )
                 )
-            )
+            } else if (
+                HtmlUtils.containsHtmlMarkup(comment) ||
+                containsAtLeastNChars(comment, 15, RU_CHARS) ||
+                containsStopwords(comment)
+            ) {
+                msgs.add(
+                    this.error(
+                        ctx.elementName,
+                        "{constraints.Comment.message}",
+                        *arrayOf(Arg("currentValue", ctx.validatedValue as Serializable))
+                    )
+                )
+            }
         }
 
         return msgs
@@ -39,37 +45,18 @@ class CommentValidator : AbstractValidator<String>() {
 
     private fun containsAtLeastNChars(str: String, n: Int, chars: Set<Char>): Boolean = str.count { chars.contains(it) } >= n
 
-    private fun startsWithLink(comment: String): Boolean {
-        val trimmedComment = comment.trim()
-        return trimmedComment.startsWith("http://") || trimmedComment.startsWith("https://")
-    }
+    private fun containsLink(comment: String): Boolean = LINK_PATTERN.containsMatchIn(comment)
 
     private fun containsStopwords(comment: String): Boolean {
         val lowerComment = comment.lowercase()
         return STOPWORDS.any { stopword -> lowerComment.contains(stopword) }
     }
 
-    private fun startsOrEndsWithRuLink(comment: String): Boolean {
-        val trimmedComment = comment.trim()
-        // Check if starts with link ending in .ru or .ru/
-        val startsWithRuLink = trimmedComment.split(Regex("\\s+")).firstOrNull()?.let { firstWord ->
-            (firstWord.startsWith("http://") || firstWord.startsWith("https://")) &&
-                (firstWord.endsWith(".ru") || firstWord.contains(".ru/"))
-        } ?: false
-
-        // Check if ends with link ending in .ru or .ru/
-        val endsWithRuLink = trimmedComment.split(Regex("\\s+")).lastOrNull()?.let { lastWord ->
-            (lastWord.startsWith("http://") || lastWord.startsWith("https://")) &&
-                (lastWord.endsWith(".ru") || lastWord.contains(".ru/"))
-        } ?: false
-
-        return startsWithRuLink || endsWithRuLink
-    }
-
     companion object {
         val RU_CHARS =
             setOf('б', 'в', 'г', 'д', 'ж', 'з', 'и', 'й', 'к', 'л', 'м', 'н', 'п', 'т', 'ф', 'ц', 'ч', 'ш', 'щ', 'ъ', 'ы', 'ь', 'э', 'ю', 'я')
         val STOPWORDS = setOf("viagra", "cialis", "levitra")
+        val LINK_PATTERN = Regex("https?://\\S+|www\\.\\S+")
 
         val INSTANCE = CommentValidator()
     }

--- a/src/main/resources/sql/insert_localisation.sql
+++ b/src/main/resources/sql/insert_localisation.sql
@@ -119,6 +119,7 @@ INSERT INTO localisation (entry_key, entry_value) VALUES ('constraints.Email.mes
 INSERT INTO localisation (entry_key, entry_value) VALUES ('constraints.Phone.message', 'Zadejte prosím validní telefonní číslo.');
 INSERT INTO localisation (entry_key, entry_value) VALUES ('constraints.URL.message', 'Zadejte prosím validní URL adresu.');
 INSERT INTO localisation (entry_key, entry_value) VALUES ('constraints.Comment.message', 'Komentář obsahuje nepovolený obsah.');
+INSERT INTO localisation (entry_key, entry_value) VALUES ('constraints.Comment.containsLink.message', 'Komentář nesmí obsahovat odkazy (URL adresy).');
 
 -- Consent-related error messages:
 INSERT INTO localisation (entry_key, entry_value) VALUES ('error.consent-required.message', 'Pro stažení produktu je třeba potvrzení souhlasu. Prosím zkontrolujte Váš profil nebo emailovou schránku a potvrďte požadované souhlasy.');

--- a/src/main/resources/sql/insert_localisation.sql
+++ b/src/main/resources/sql/insert_localisation.sql
@@ -119,7 +119,6 @@ INSERT INTO localisation (entry_key, entry_value) VALUES ('constraints.Email.mes
 INSERT INTO localisation (entry_key, entry_value) VALUES ('constraints.Phone.message', 'Zadejte prosím validní telefonní číslo.');
 INSERT INTO localisation (entry_key, entry_value) VALUES ('constraints.URL.message', 'Zadejte prosím validní URL adresu.');
 INSERT INTO localisation (entry_key, entry_value) VALUES ('constraints.Comment.message', 'Komentář obsahuje nepovolený obsah.');
-INSERT INTO localisation (entry_key, entry_value) VALUES ('constraints.Comment.containsLink.message', 'Komentář nesmí obsahovat odkazy (URL adresy).');
 
 -- Consent-related error messages:
 INSERT INTO localisation (entry_key, entry_value) VALUES ('error.consent-required.message', 'Pro stažení produktu je třeba potvrzení souhlasu. Prosím zkontrolujte Váš profil nebo emailovou schránku a potvrďte požadované souhlasy.');

--- a/src/test/kotlin/org/xbery/artbeams/comments/controller/CommentValidatorTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/comments/controller/CommentValidatorTest.kt
@@ -52,78 +52,48 @@ class CommentValidatorTest :
             errors shouldHaveSize 1
         }
 
-        // Tests for .ru domain links at the start
-        "should reject comment starting with .ru link" {
-            val ctx = createValidationContext("https://example.ru This is spam content")
+        // Tests for links in comments
+        "should reject comment starting with link" {
+            val ctx = createValidationContext("https://example.com Check this out")
             val errors = validator.validate(ctx)
             errors shouldHaveSize 1
         }
 
-        "should reject comment starting with .ru/ link" {
-            val ctx = createValidationContext("https://example.ru/ Some spam text here")
+        "should reject comment ending with link" {
+            val ctx = createValidationContext("Check out this site https://example.ru")
             val errors = validator.validate(ctx)
             errors shouldHaveSize 1
         }
 
-        "should reject comment starting with http .ru link" {
-            val ctx = createValidationContext("http://spam.ru Check out this site")
+        "should reject comment with link in the middle" {
+            val ctx = createValidationContext("Explore the latest additions here — http://www.tiroavolobologna.it/media/pgs/le-code-promo-1xbet_bonus.html")
             val errors = validator.validate(ctx)
             errors shouldHaveSize 1
         }
 
-        // Tests for .ru domain links at the end
-        "should reject comment ending with .ru link" {
-            val ctx = createValidationContext("Check out this spam site https://example.ru")
+        "should reject comment with http link" {
+            val ctx = createValidationContext("Visit http://spam.ru for more info")
             val errors = validator.validate(ctx)
             errors shouldHaveSize 1
         }
 
-        "should reject comment ending with .ru/ link" {
-            val ctx = createValidationContext("Visit our website https://example.ru/")
+        "should reject comment with https link" {
+            val ctx = createValidationContext("More at https://example.ru/path/to/page")
             val errors = validator.validate(ctx)
             errors shouldHaveSize 1
         }
 
-        "should reject comment ending with http .ru link" {
-            val ctx = createValidationContext("More info at http://spam.ru")
-            val errors = validator.validate(ctx)
-            errors shouldHaveSize 1
-        }
-
-        // Tests for .ru links with paths
-        "should reject comment starting with .ru link containing path" {
-            val ctx = createValidationContext("https://example.ru/path/to/page some text")
-            val errors = validator.validate(ctx)
-            errors shouldHaveSize 1
-        }
-
-        "should reject comment ending with .ru link containing path" {
-            val ctx = createValidationContext("some text https://example.ru/path/to/page")
+        "should reject comment with www link" {
+            val ctx = createValidationContext("Visit www.example.com for details")
             val errors = validator.validate(ctx)
             errors shouldHaveSize 1
         }
 
         // Tests for legitimate comments (should not be rejected)
-        "should allow comment without stopwords or .ru links" {
+        "should allow comment without links or stopwords" {
             val ctx = createValidationContext("This is a normal comment about something interesting")
             val errors = validator.validate(ctx)
             errors.shouldBeEmpty()
-        }
-
-        "should allow comment with .ru link in the middle" {
-            val ctx = createValidationContext("I found this https://example.ru which is interesting")
-            val errors = validator.validate(ctx)
-            // This should still pass because the link is not at the start or end
-            // Actually, looking at the implementation, it checks for .ru at start OR end, so this should be rejected
-            // Let me reconsider: if a link is in the middle, it's neither the first word nor the last word
-            errors.shouldBeEmpty()
-        }
-
-        "should allow comment with .com link at start" {
-            val ctx = createValidationContext("https://example.com Check this out")
-            val errors = validator.validate(ctx)
-            // This should fail because startsWithLink() checks for any link at the start
-            errors shouldHaveSize 1
         }
 
         "should allow comment mentioning Russia (not the stopwords)" {


### PR DESCRIPTION
## Summary
Refactored the comment validator to use a single regex pattern for detecting all types of links (http, https, and www) instead of multiple specialized methods. This simplifies the validation logic while maintaining the same spam detection capability.

## Key Changes
- Replaced `startsWithLink()` and `startsOrEndsWithRuLink()` methods with a unified `containsLink()` method using regex pattern matching
- Introduced `LINK_PATTERN` regex (`https?://\S+|www\.\S+`) to detect any URL-like content in comments
- Simplified validation logic by removing domain-specific (.ru) checks in favor of generic link detection
- Updated test cases to reflect the new generic link detection approach, removing .ru-specific test cases and replacing them with domain-agnostic tests

## Implementation Details
- The new `LINK_PATTERN` regex matches:
  - HTTP/HTTPS URLs: `https?://\S+`
  - WWW links: `www\.\S+`
- The pattern is checked anywhere in the comment text, not just at the start or end
- This approach is more maintainable and catches a broader range of spam patterns without hardcoding specific domains

https://claude.ai/code/session_01Br5dv7rB9rvru9xnoPC5o1