### PR TITLE
Add Content Signals to robots.txt

### DIFF
--- a/src/main/resources/robots.txt
+++ b/src/main/resources/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
+Content-Signal: ai-train=yes, search=yes, ai-input=no
 Disallow: /WEB-INF/
 Disallow: /ochrana-osobnich-udaju
 Disallow: /obchodni-podminky


### PR DESCRIPTION
Implements Content Signals directive in robots.txt.

- Adds Content-Signal: ai-train=yes, search=yes, ai-input=no under User-agent: *.

Fixes #18.

Notes:
- Local ./gradlew test could not be run in this environment because no Java runtime is available (JAVA_HOME not set).