### PR TITLE
Enable Markdown for Agents via Accept negotiation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ dependencies {
     // Markdown support
     implementation("com.vladsch.flexmark:flexmark:0.50.28")
     implementation("com.vladsch.flexmark:flexmark-ext-attributes:0.50.28")
+    implementation("com.vladsch.flexmark:flexmark-html2md-converter:0.50.28")
     implementation("javax.inject:javax.inject:1")
 
     // Detection of client - browser capabilities

--- a/src/main/kotlin/org/xbery/artbeams/common/markdown/HtmlToMarkdownConverter.kt
+++ b/src/main/kotlin/org/xbery/artbeams/common/markdown/HtmlToMarkdownConverter.kt
@@ -1,0 +1,40 @@
+package org.xbery.artbeams.common.markdown
+
+import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter
+import com.vladsch.flexmark.util.data.MutableDataSet
+import org.springframework.stereotype.Service
+
+@Service
+class HtmlToMarkdownConverter {
+    private val htmlConverter: FlexmarkHtmlConverter
+
+    init {
+        val options = MutableDataSet()
+        htmlConverter = FlexmarkHtmlConverter.builder(options).build()
+    }
+
+    fun htmlToMarkdown(html: String): String {
+        val cleanedHtml = stripNonContentHtml(html)
+        return htmlConverter.convert(cleanedHtml).trim() + "\n"
+    }
+
+    private fun stripNonContentHtml(html: String): String {
+        return html
+            .replace(Regex("(?is)<script\\b[^>]*>.*?</script>"), "")
+            .replace(Regex("(?is)<style\\b[^>]*>.*?</style>"), "")
+            .replace(Regex("(?is)<noscript\\b[^>]*>.*?</noscript>"), "")
+    }
+
+    /**
+     * Best-effort approximation of token count (not model-specific).
+     * Intended only for coarse sizing via `x-markdown-tokens`.
+     */
+    fun estimateTokens(markdown: String): Int {
+        val normalized = markdown.trim()
+        if (normalized.isEmpty()) return 0
+
+        // Rough token approximation: words, numbers and punctuation as separate units.
+        // This is intentionally lightweight and does not attempt to replicate any specific model tokenizer.
+        return Regex("[A-Za-z]+|\\d+|[^\\sA-Za-z\\d]").findAll(normalized).count()
+    }
+}

--- a/src/main/kotlin/org/xbery/artbeams/web/filter/MarkdownNegotiationServletFilter.kt
+++ b/src/main/kotlin/org/xbery/artbeams/web/filter/MarkdownNegotiationServletFilter.kt
@@ -1,0 +1,112 @@
+package org.xbery.artbeams.web.filter
+
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.annotation.Order
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.util.ContentCachingResponseWrapper
+import org.xbery.artbeams.common.markdown.HtmlToMarkdownConverter
+import java.util.Collections
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+/**
+ * Supports `Accept: text/markdown` content negotiation so agents can request a markdown version of HTML pages.
+ */
+@Component
+@Order(100)
+class MarkdownNegotiationServletFilter(
+    private val htmlToMarkdownConverter: HtmlToMarkdownConverter,
+) : Filter {
+
+    override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+        if (request !is HttpServletRequest || response !is HttpServletResponse) {
+            chain.doFilter(request, response)
+            return
+        }
+
+        if (request.method.uppercase() != "GET") {
+            chain.doFilter(request, response)
+            return
+        }
+
+        response.setHeader(HttpHeaders.VARY, appendVaryValue(response.getHeader(HttpHeaders.VARY), HttpHeaders.ACCEPT))
+
+        val wantsMarkdown = requestWantsMarkdown(request)
+        if (!wantsMarkdown) {
+            chain.doFilter(request, response)
+            return
+        }
+
+        val cachingResponse = ContentCachingResponseWrapper(response)
+        chain.doFilter(request, cachingResponse)
+
+        val status = cachingResponse.status
+        val contentType = cachingResponse.contentType.orEmpty()
+        val bodyBytes = cachingResponse.contentAsByteArray
+
+        val isHtml =
+            contentType.startsWith(MediaType.TEXT_HTML_VALUE) ||
+                contentType.startsWith("${MediaType.TEXT_HTML_VALUE};")
+
+        if (status in 200..299 && isHtml && bodyBytes.isNotEmpty() && bodyBytes.size <= MAX_HTML_BYTES_FOR_CONVERSION) {
+            val charset = responseCharset(cachingResponse.characterEncoding)
+            val html = bodyBytes.toString(charset)
+            val markdown = htmlToMarkdownConverter.htmlToMarkdown(html)
+            val tokenCount = htmlToMarkdownConverter.estimateTokens(markdown)
+            val markdownBytes = markdown.toByteArray(StandardCharsets.UTF_8)
+
+            response.contentType = "${MARKDOWN_MEDIA_TYPE}; charset=${StandardCharsets.UTF_8.name()}"
+            response.setHeader(X_MARKDOWN_TOKENS_HEADER, tokenCount.toString())
+
+            response.resetBuffer()
+            response.setContentLength(markdownBytes.size)
+            response.outputStream.write(markdownBytes)
+            response.flushBuffer()
+        } else {
+            cachingResponse.copyBodyToResponse()
+        }
+    }
+
+    private fun responseCharset(encoding: String?): Charset {
+        return try {
+            if (encoding.isNullOrBlank()) StandardCharsets.UTF_8 else Charset.forName(encoding)
+        } catch (_: Exception) {
+            StandardCharsets.UTF_8
+        }
+    }
+
+    private fun requestWantsMarkdown(request: HttpServletRequest): Boolean {
+        val acceptHeaders = Collections.list(request.getHeaders(HttpHeaders.ACCEPT))
+        if (acceptHeaders.isEmpty()) return false
+
+        val markdown = MediaType.parseMediaType(MARKDOWN_MEDIA_TYPE)
+        return MediaType.parseMediaTypes(acceptHeaders)
+            .sortedByDescending { it.qualityValue }
+            .any { it.qualityValue > 0.0 && it.isCompatibleWith(markdown) }
+    }
+
+    private fun appendVaryValue(existing: String?, value: String): String {
+        val existingValues =
+            existing
+                ?.split(",")
+                ?.map { it.trim() }
+                ?.filter { it.isNotEmpty() }
+                .orEmpty()
+                .toMutableSet()
+        existingValues.add(value)
+        return existingValues.joinToString(", ")
+    }
+
+    companion object {
+        private const val MARKDOWN_MEDIA_TYPE = "text/markdown"
+        private const val X_MARKDOWN_TOKENS_HEADER = "x-markdown-tokens"
+        private const val MAX_HTML_BYTES_FOR_CONVERSION = 2_097_152 // 2 MiB
+    }
+}

--- a/src/test/kotlin/org/xbery/artbeams/web/filter/MarkdownNegotiationServletFilterTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/web/filter/MarkdownNegotiationServletFilterTest.kt
@@ -1,0 +1,119 @@
+package org.xbery.artbeams.web.filter
+
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletResponse
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.xbery.artbeams.common.markdown.HtmlToMarkdownConverter
+
+class MarkdownNegotiationServletFilterTest {
+
+    private val htmlToMarkdownConverter = HtmlToMarkdownConverter()
+    private val filter = MarkdownNegotiationServletFilter(htmlToMarkdownConverter)
+
+    @Test
+    fun `returns markdown when Accept is text markdown`() {
+        val request = MockHttpServletRequest("GET", "/")
+        request.addHeader(HttpHeaders.ACCEPT, "text/markdown, text/html;q=0.9")
+
+        val response = MockHttpServletResponse()
+
+        val chain = FilterChain { _, res ->
+            val httpRes = res as HttpServletResponse
+            httpRes.contentType = "text/html; charset=UTF-8"
+            httpRes.writer.write("<html><body><h1>Hello</h1><p>World</p></body></html>")
+        }
+
+        filter.doFilter(request, response, chain)
+
+        response.contentType.shouldContain("text/markdown")
+        response.getHeader(HttpHeaders.VARY).split(",").map { it.trim() }.shouldContain(HttpHeaders.ACCEPT)
+
+        val tokenCount = response.getHeader("x-markdown-tokens").toInt()
+        (tokenCount > 0).shouldBe(true)
+
+        val body = response.contentAsString
+        body.shouldContain("Hello")
+        body.shouldContain("World")
+        body.shouldNotContain("<html")
+    }
+
+    @Test
+    fun `returns html by default`() {
+        val request = MockHttpServletRequest("GET", "/")
+        val response = MockHttpServletResponse()
+
+        val chain = FilterChain { _, res ->
+            val httpRes = res as HttpServletResponse
+            httpRes.contentType = "text/html; charset=UTF-8"
+            httpRes.writer.write("<html><body><p>Only HTML</p></body></html>")
+        }
+
+        filter.doFilter(request, response, chain)
+
+        response.contentType.shouldContain("text/html")
+        response.getHeader(HttpHeaders.VARY).split(",").map { it.trim() }.shouldContain(HttpHeaders.ACCEPT)
+        response.contentAsString.shouldContain("Only HTML")
+    }
+
+    @Test
+    fun `does not return markdown when q is zero`() {
+        val request = MockHttpServletRequest("GET", "/")
+        request.addHeader(HttpHeaders.ACCEPT, "text/markdown;q=0, text/html")
+
+        val response = MockHttpServletResponse()
+        val chain = FilterChain { _, res ->
+            val httpRes = res as HttpServletResponse
+            httpRes.contentType = "text/html; charset=UTF-8"
+            httpRes.writer.write("<html><body><p>Only HTML</p></body></html>")
+        }
+
+        filter.doFilter(request, response, chain)
+
+        response.contentType.shouldContain("text/html")
+        response.contentAsString.shouldContain("Only HTML")
+    }
+
+    @Test
+    fun `passes through non html responses`() {
+        val request = MockHttpServletRequest("GET", "/api/ping")
+        request.addHeader(HttpHeaders.ACCEPT, "text/markdown")
+
+        val response = MockHttpServletResponse()
+        val chain = FilterChain { _, res ->
+            val httpRes = res as HttpServletResponse
+            httpRes.contentType = "application/json"
+            httpRes.writer.write("{\"ok\":true}")
+        }
+
+        filter.doFilter(request, response, chain)
+
+        response.contentType.shouldContain("application/json")
+        response.contentAsString.shouldContain("{\"ok\":true}")
+    }
+
+    @Test
+    fun `merges existing vary header`() {
+        val request = MockHttpServletRequest("GET", "/")
+        val response = MockHttpServletResponse()
+        response.setHeader(HttpHeaders.VARY, "Accept-Encoding")
+
+        val chain = FilterChain { _, res ->
+            val httpRes = res as HttpServletResponse
+            httpRes.contentType = "text/html; charset=UTF-8"
+            httpRes.writer.write("<html><body><p>Only HTML</p></body></html>")
+        }
+
+        filter.doFilter(request, response, chain)
+
+        val varyValues = response.getHeader(HttpHeaders.VARY).split(",").map { it.trim() }
+        varyValues.shouldContain("Accept-Encoding")
+        varyValues.shouldContain(HttpHeaders.ACCEPT)
+    }
+}


### PR DESCRIPTION
Implements Markdown content negotiation: requests with Accept: text/markdown receive a markdown representation of HTML pages (Content-Type: text/markdown) while HTML remains the default. Adds Vary: Accept and x-markdown-tokens, plus unit tests.

Fixes #17.

Note: local test execution was not possible in this environment due to missing Java runtime; please rely on CI.