### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781452801283.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781452801283.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781452801283",
+  "planning": {
+    "input": 89326,
+    "cached_input": 887424,
+    "cache_write": 0,
+    "output": 4218,
+    "reasoning": 2324,
+    "cost": 0.403208,
+    "updated_at": "2026-06-14T16:02:30.328Z"
+  }
+}

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,10 +2,12 @@
 <!-- To suggest work, add items to "## Later / ideas" below. The planner will promote them when capacity opens up. -->
 
 ## Next up (ready)
-<!-- Issues that are ready for the implementer to pick up this sprint. The planner keeps this section populated up to the configured depth. -->
+- Implement Courses+Modules persistence and admin CRUD (schema, repositories, services, `/admin/courses` UI) touching `src/main/resources/sql/create_tables.sql`, `src/main/resources/sql/migrations/`, and new `src/main/kotlin/org/xbery/artbeams/courses/**` files plus `src/main/resources/templates/admin/courses/**`.
+- Add Course/Module assignment into article admin editor by extending `src/main/kotlin/org/xbery/artbeams/articles/domain/{Article,EditedArticle}.kt`, `articles/repository/mapper/*`, `articles/admin/{ArticleForm,ArticleAdminController}.kt`, and `src/main/resources/templates/admin/articles/articleEdit.ftl`.
+- Deliver member Courses experience with access checks and private search (course menu and pages in member section, plus private-index guard in `src/main/kotlin/org/xbery/artbeams/search/service/SearchIndexer.kt` and gated article/course routes).
 
 ## Later / ideas
-<!-- Candidates for future sprints or lower-priority work. Humans may add items here; the planner evaluates and promotes or skips them. -->
+- Add idempotent e2e seed SQL script (`scripts/seed_courses_e2e.sql`) to provision admin/member users, purchased product, course, modules, and linked articles for Chrome DevTools journey tests; this is needed for repeatable sprint DoD verification but should follow core feature scaffolding.
 
 ## Done (recent)
 <!-- Issues closed as completed in recent planning cycles. The planner moves items here automatically. -->

--- a/sprint-state.json
+++ b/sprint-state.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "status": "active",
+  "verdict": "in_progress",
+  "setBy": "system",
+  "updatedAt": "2026-06-14T16:00:30.517Z",
+  "evidence": [],
+  "unmet": [],
+  "notes": "",
+  "blockers": []
+}


### PR DESCRIPTION
## Planning run
_Reconciled: BACKLOG.md started empty, so I populated Next up from SPRINT.md seed candidates and prioritized the foundational admin/persistence slice first. Picked: one issue only (run cap is 1) that is concrete, grounded to existing project structure (Asset/AssetRepository patterns, admin templates/controllers, SQL+JOOQ workflow), and directly tied to sprint success conditions. Skipped: member-section delivery and article-assignment/search hardening were kept in Next up rather than issued now due to the hard cap and dependency on core Courses data/admin primitives. I also kept the e2e seed script in Later because it is valuable for DoD verification but should follow initial feature scaffolding. Risks: the issue spans schema + service + admin UI, so strict scope control is needed to keep it within L; acceptance criteria include a focused service test and explicit Chrome DevTools MCP flow to reduce regression risk. Risks: once this lands, the next issue should immediately cover article assignment and private-search exclusion to close remaining failure conditions quickly._
**Stuck/state snapshot:** 0 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Implement Courses and Modules admin CRUD with product assignment** (estimate: L)

   Deliver an administrator-facing Courses feature so admins can create/edit/delete Courses, define Modules inside a Course, and assign each Course to one or more Products. This provides the private-content management baseline required before member access flows can work.
   
   Context: implement schema + migration in `src/main/resources/sql/create_tables.sql` and `src/main/resources/sql/migrations/add_courses_modules.sql`; add `org.xbery.artbeams.courses` domain/repository/service/admin packages under `src/main/kotlin`; add admin templates under `src/main/resources/templates/admin/courses`; add Courses link in `src/main/resources/templates/adminLayout.ftl`.
   
   ## Acceptance Criteria
   1. Database and JOOQ model support Courses/Modules: `create_tables.sql` defines `courses`, `modules`, `product_course` and required indexes/foreign keys, and `add_courses_modules.sql` is idempotent (`IF NOT EXISTS` / guarded alters); running `./gradlew generateJooq` generates `CoursesRecord`, `ModulesRecord`, and `ProductCourseRecord`.
   2. New `Course` and `Module` entities derive from `Asset` and repositories derive from `AssetRepository` (`CourseRepository`, `ModuleRepository`) with mappers/unmappers; `CourseService` exposes save/list/find-by-slug and product-assignment behavior used by admin controllers.
   3. Admin UI exists at `/admin/courses` and `/admin/courses/{courseId}/modules` with list/edit/save/delete flows and product multi-assignment on course edit; admin navbar includes a Courses entry in `adminLayout.ftl`.
   4. Programmatic test coverage is added in `src/test/kotlin/org/xbery/artbeams/courses/service/CourseServiceImplTest.kt` (or equivalent) asserting that `findCoursesForUser` returns only courses linked through purchased products (`user_product` + `product_course`) and that module ordering by `sort_order` is preserved; test passes via `./gradlew test --tests "org.xbery.artbeams.courses.service.CourseServiceImplTest"`.
   5. Browser-driven verification (Chrome DevTools MCP): run app via `./start.sh`, log in as admin, navigate to `/admin/courses`, create a Course, assign at least one Product, add two Modules, reload list/detail pages, and verify created records are visible and persisted without console/network errors.
   
   @worker
   Scope: L
   
   ---
   _Grade: 5/5 | Covers: Administration of Courses is implemented, allowing administrators to create and manage Courses (sets of articles) and assign them to products, create list of modules within this course - each module with image, title, short description and perex content (introduction text). | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._