### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781456401707.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781456401707.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781456401707",
+  "planning": {
+    "input": 84209,
+    "cached_input": 1021952,
+    "cache_write": 0,
+    "output": 4174,
+    "reasoning": 4032,
+    "cost": 0.441091,
+    "updated_at": "2026-06-14T17:03:06.277Z"
+  }
+}

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,12 +2,12 @@
 <!-- To suggest work, add items to "## Later / ideas" below. The planner will promote them when capacity opens up. -->
 
 ## Next up (ready)
-- Implement Courses+Modules persistence and admin CRUD (schema, repositories, services, `/admin/courses` UI) touching `src/main/resources/sql/create_tables.sql`, `src/main/resources/sql/migrations/`, and new `src/main/kotlin/org/xbery/artbeams/courses/**` files plus `src/main/resources/templates/admin/courses/**`.
-- Add Course/Module assignment into article admin editor by extending `src/main/kotlin/org/xbery/artbeams/articles/domain/{Article,EditedArticle}.kt`, `articles/repository/mapper/*`, `articles/admin/{ArticleForm,ArticleAdminController}.kt`, and `src/main/resources/templates/admin/articles/articleEdit.ftl`.
-- Deliver member Courses experience with access checks and private search (course menu and pages in member section, plus private-index guard in `src/main/kotlin/org/xbery/artbeams/search/service/SearchIndexer.kt` and gated article/course routes).
+- Deliver member Courses experience with strict access checks and private search (course menu and member pages in `src/main/kotlin/org/xbery/artbeams/members/controller/MemberSectionController.kt`, new `src/main/kotlin/org/xbery/artbeams/courses/controller/**`, member templates under `src/main/resources/templates/member/**`, private-index guard in `src/main/kotlin/org/xbery/artbeams/search/service/SearchIndexer.kt`, and gated article/course routes in `src/main/kotlin/org/xbery/artbeams/web/WebController.kt`).
+- Add Course/Module assignment into article admin editor by extending `src/main/kotlin/org/xbery/artbeams/articles/domain/{Article,EditedArticle}.kt`, `src/main/kotlin/org/xbery/artbeams/articles/repository/mapper/*`, `src/main/kotlin/org/xbery/artbeams/articles/admin/{ArticleForm,ArticleAdminController}.kt`, and `src/main/resources/templates/admin/articles/articleEdit.ftl`.
+- Add idempotent e2e seed SQL script (`scripts/seed_courses_e2e.sql`) to provision admin/member users, purchased product, course, modules, and linked articles for Chrome DevTools journey tests; include deterministic IDs and safe re-run semantics aligned with `src/main/resources/sql/create_tables.sql` and `src/main/resources/sql/migrations/*.sql`.
 
 ## Later / ideas
-- Add idempotent e2e seed SQL script (`scripts/seed_courses_e2e.sql`) to provision admin/member users, purchased product, course, modules, and linked articles for Chrome DevTools journey tests; this is needed for repeatable sprint DoD verification but should follow core feature scaffolding.
+<!-- To suggest work, add items to "## Later / ideas" below. The planner will promote them when capacity opens up. -->
 
 ## Done (recent)
 <!-- Issues closed as completed in recent planning cycles. The planner moves items here automatically. -->


### PR DESCRIPTION
## Planning run
_Reconciled: removed the in-flight admin CRUD backlog item from `Next up` because it already maps to open issue #27, and reordered remaining ready work to prioritize unresolved sprint failure conditions; also promoted the grounded e2e seed-script item from Later to Next up to keep a healthy ready queue. Picked: one issue only (cap=1), choosing member-only Course access + private search because it maps directly to two explicit failure-condition bullets and multiple DoD bullets in SPRINT.md. Skipped: did not re-propose persistence/admin CRUD because it would duplicate open issue #27, and did not open the article-editor assignment item this run due tighter priority on access/search safety. Risks: this issue likely integrates with schema/domain artifacts landing from #27, so sequencing and merge coordination are important to avoid temporary compile breaks. Risks are mitigated by explicit test criteria and browser-driven verification of entitlement and search isolation. No deployment/infra human blocker is required from the current evidence (no secrets, DNS, or external SaaS action identified as a hard prerequisite)._
**Stuck/state snapshot:** 1 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Implement member-only Course pages and private Course search** (estimate: L)

   Add the member-facing Courses experience so entitled member users can see their Courses in `/clenska-sekce`, open Course/module/article pages, and search only within Courses they purchased. This closes the current private-content exposure gap by enforcing entitlement checks in routing and search visibility.
   
   Context: implement in `src/main/kotlin/org/xbery/artbeams/members/controller/MemberSectionController.kt`, new `src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt` + `courses/service/**`, `src/main/resources/templates/member/memberSection.ftl` and new member course templates, `src/main/kotlin/org/xbery/artbeams/search/service/SearchIndexer.kt`, and gate public slug rendering in `src/main/kotlin/org/xbery/artbeams/web/WebController.kt` / article lookup path.
   
   ## Acceptance Criteria
   1. Member home (`GET /clenska-sekce`) renders a top Course menu before product tiles only when at least one purchased product maps to a Course; users without entitled Courses do not see the menu.
   2. Course/module/detail endpoints under member section require `member` auth and ownership checks against purchased products; requesting a Course not linked to the logged-in user returns forbidden/not-found and does not leak private article metadata.
   3. Public search isolation is enforced: `SearchIndexer.indexArticle` and `SearchIndexer.reindexAll` skip course-linked articles, and `/search?query=...` does not return Course-only content.
   4. Programmatic coverage is added in tests (e.g. `src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerAccessTest.kt` and `src/test/kotlin/org/xbery/artbeams/search/service/SearchIndexerCourseIsolationTest.kt`) and passes via `./gradlew test --tests "*Course*" --tests "*SearchIndexer*"`.
   5. Browser-driven verification with Chrome DevTools MCP on local app: log in as an entitled member, navigate `/clenska-sekce`, confirm Course menu appears, open Course detail and module/article pages, submit Course search form and verify only in-course entitled results are shown; then log in as non-entitled member and verify Course link/URL access is denied.
   
   @worker
   Scope: L
   
   ---
   _Grade: 5/5 | Covers: User logged in member section can search per each Course, in all Courses he has access to, and see the articles in search results. Content from the private article set is not pre-indexed. User can search separately within each Course via its search form. Results from publicly indexed articles or from another Courses are not displayed. | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._