### PR TITLE
Add idempotent E2E seed script for Courses (FKs, metadata columns, indexes)

### DIFF
--- a/.autoworker/cost/issue-31.json
+++ b/.autoworker/cost/issue-31.json
@@ -1,0 +1,13 @@
+{
+  "issue": 31,
+  "implementation": {
+    "input": 130630,
+    "cached_input": 458368,
+    "cache_write": 0,
+    "output": 9316,
+    "reasoning": 10688,
+    "cost": 0.084125,
+    "updated_at": "2026-06-15T09:00:38.908Z"
+  },
+  "review": null
+}

--- a/.autoworker/cost/issue-31.json
+++ b/.autoworker/cost/issue-31.json
@@ -9,5 +9,13 @@
     "cost": 0.084125,
     "updated_at": "2026-06-15T09:00:38.908Z"
   },
-  "review": null
+  "review": {
+    "input": 19510,
+    "cached_input": 52608,
+    "cache_write": 0,
+    "output": 2843,
+    "reasoning": 1216,
+    "cost": 0.014311,
+    "updated_at": "2026-06-15T09:02:11.001Z"
+  }
 }

--- a/scripts/seed_courses_e2e.sql
+++ b/scripts/seed_courses_e2e.sql
@@ -1,0 +1,160 @@
+-- Usage:
+-- psql -U artbeams_user -d artbeams -f scripts/seed_courses_e2e.sql
+--
+-- Idempotent seed for Courses E2E tests.
+-- Safe to re-run: objects are created IF NOT EXISTS and inserts use deterministic IDs
+-- so running the script multiple times does not create duplicates.
+
+BEGIN;
+
+-- Create courses related tables if they don't exist yet (idempotent)
+CREATE TABLE IF NOT EXISTS courses (
+  id VARCHAR(40) NOT NULL PRIMARY KEY,
+  created timestamp NOT NULL,
+  modified timestamp NOT NULL,
+  -- Align with project conventions: creator / modifier user references (nullable)
+  created_by VARCHAR(40) DEFAULT NULL,
+  modified_by VARCHAR(40) DEFAULT NULL,
+  slug VARCHAR(128) NOT NULL,
+  title VARCHAR(128) NOT NULL,
+  perex VARCHAR(2000) DEFAULT NULL,
+  description TEXT DEFAULT NULL,
+  draft boolean NOT NULL DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS idx_courses_slug ON courses (slug);
+
+CREATE TABLE IF NOT EXISTS modules (
+  id VARCHAR(40) NOT NULL PRIMARY KEY,
+  created timestamp NOT NULL,
+  modified timestamp NOT NULL,
+  -- Align with project conventions: creator / modifier user references (nullable)
+  created_by VARCHAR(40) DEFAULT NULL,
+  modified_by VARCHAR(40) DEFAULT NULL,
+  course_id VARCHAR(40) NOT NULL,
+  slug VARCHAR(128) DEFAULT NULL,
+  title VARCHAR(128) DEFAULT NULL,
+  description TEXT DEFAULT NULL,
+  sort_order integer DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_modules_course_id ON modules (course_id);
+CREATE INDEX IF NOT EXISTS idx_modules_course_sort ON modules (course_id, sort_order);
+
+CREATE TABLE IF NOT EXISTS product_course (
+  product_id VARCHAR(40) NOT NULL,
+  course_id VARCHAR(40) NOT NULL,
+  PRIMARY KEY (product_id, course_id)
+);
+CREATE INDEX IF NOT EXISTS idx_product_course_product_id ON product_course (product_id);
+CREATE INDEX IF NOT EXISTS idx_product_course_course_id ON product_course (course_id);
+
+-- Add course/module columns to articles if missing (safe to run multiple times)
+ALTER TABLE articles ADD COLUMN IF NOT EXISTS course_id VARCHAR(40) DEFAULT NULL;
+ALTER TABLE articles ADD COLUMN IF NOT EXISTS module_id VARCHAR(40) DEFAULT NULL;
+
+-- Add indexes for article course/module lookups
+CREATE INDEX IF NOT EXISTS idx_articles_course_id ON articles (course_id);
+CREATE INDEX IF NOT EXISTS idx_articles_module_id ON articles (module_id);
+
+-- Add foreign key constraints if missing. Use plpgsql blocks to check existence first.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_modules_course_id') THEN
+    ALTER TABLE modules ADD CONSTRAINT fk_modules_course_id FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_product_course_product') THEN
+    ALTER TABLE product_course ADD CONSTRAINT fk_product_course_product FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_product_course_course') THEN
+    ALTER TABLE product_course ADD CONSTRAINT fk_product_course_course FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_articles_course') THEN
+    ALTER TABLE articles ADD CONSTRAINT fk_articles_course FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_articles_module') THEN
+    ALTER TABLE articles ADD CONSTRAINT fk_articles_module FOREIGN KEY (module_id) REFERENCES modules(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_courses_created_by') THEN
+    ALTER TABLE courses ADD CONSTRAINT fk_courses_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_courses_modified_by') THEN
+    ALTER TABLE courses ADD CONSTRAINT fk_courses_modified_by FOREIGN KEY (modified_by) REFERENCES users(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_modules_created_by') THEN
+    ALTER TABLE modules ADD CONSTRAINT fk_modules_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_modules_modified_by') THEN
+    ALTER TABLE modules ADD CONSTRAINT fk_modules_modified_by FOREIGN KEY (modified_by) REFERENCES users(id) ON DELETE SET NULL;
+  END IF;
+END$$;
+
+-- Insert roles (deterministic ids)
+INSERT INTO roles (id, created, created_by, modified, modified_by, name)
+VALUES ('role-admin', now(), 'seed', now(), 'seed', 'ADMIN')
+ON CONFLICT (id) DO NOTHING;
+INSERT INTO roles (id, created, created_by, modified, modified_by, name)
+VALUES ('role-member', now(), 'seed', now(), 'seed', 'MEMBER')
+ON CONFLICT (id) DO NOTHING;
+
+-- Insert users testadmin and testmember. Use unique login to avoid duplicates.
+-- Passwords are dummy values for testing existence only.
+INSERT INTO users (id, created, created_by, modified, modified_by, login, password, first_name, last_name, email)
+VALUES ('user-testadmin', now(), 'seed', now(), 'seed', 'testadmin', 'password-not-secure', 'Test', 'Admin', 'testadmin@example.com')
+ON CONFLICT (login) DO UPDATE SET modified = now(), modified_by = 'seed';
+
+INSERT INTO users (id, created, created_by, modified, modified_by, login, password, first_name, last_name, email)
+VALUES ('user-testmember', now(), 'seed', now(), 'seed', 'testmember', 'password-not-secure', 'Test', 'Member', 'testmember@example.com')
+ON CONFLICT (login) DO UPDATE SET modified = now(), modified_by = 'seed';
+
+-- Grant roles to users (idempotent using WHERE NOT EXISTS)
+INSERT INTO user_role (user_id, role_id)
+SELECT u.id, r.id FROM users u, roles r
+WHERE u.login = 'testadmin' AND r.id = 'role-admin'
+  AND NOT EXISTS (SELECT 1 FROM user_role ur WHERE ur.user_id = u.id AND ur.role_id = r.id);
+
+INSERT INTO user_role (user_id, role_id)
+SELECT u.id, r.id FROM users u, roles r
+WHERE u.login = 'testmember' AND r.id = 'role-member'
+  AND NOT EXISTS (SELECT 1 FROM user_role ur WHERE ur.user_id = u.id AND ur.role_id = r.id);
+
+-- Insert a deterministic product that represents the course product
+INSERT INTO products (id, created, created_by, modified, modified_by, slug, title, price_regular)
+VALUES ('prod-kurz-zdrave', now(), 'seed', now(), 'seed', 'kurz-zdrave-stravovani', 'Kurz zdravého stravování', 1000.00)
+ON CONFLICT (id) DO UPDATE SET modified = now(), modified_by = 'seed', title = EXCLUDED.title;
+
+-- Insert the course
+INSERT INTO courses (id, created, modified, slug, title, perex, draft)
+VALUES ('course-zdrave-stravovani', now(), now(), 'zdrave-stravovani', 'Kurz zdravého stravování', 'Krátký kurs o zdravém stravování pro testy.', false)
+ON CONFLICT (id) DO UPDATE SET modified = now();
+
+-- Create two modules for the course
+INSERT INTO modules (id, created, modified, course_id, slug, title, sort_order)
+VALUES ('module-zs-1', now(), now(), 'course-zdrave-stravovani', 'zdrave-stravovani-modul-1', 'Modul 1 - Úvod', 1)
+ON CONFLICT (id) DO UPDATE SET modified = now();
+
+INSERT INTO modules (id, created, modified, course_id, slug, title, sort_order)
+VALUES ('module-zs-2', now(), now(), 'course-zdrave-stravovani', 'zdrave-stravovani-modul-2', 'Modul 2 - Pokročilé', 2)
+ON CONFLICT (id) DO UPDATE SET modified = now();
+
+-- Assign product to course (many-to-many)
+INSERT INTO product_course (product_id, course_id)
+VALUES ('prod-kurz-zdrave', 'course-zdrave-stravovani')
+ON CONFLICT (product_id, course_id) DO NOTHING;
+
+-- Create three course-scoped articles
+INSERT INTO articles (id, created, created_by, modified, modified_by, slug, title, perex, body, draft, course_id)
+VALUES
+  ('article-zs-1', now(), 'seed', now(), 'seed', 'zdrave-1', 'Zdravé jídlo 1', 'Perex 1', 'Tělo článku 1', false, 'course-zdrave-stravovani'),
+  ('article-zs-2', now(), 'seed', now(), 'seed', 'zdrave-2', 'Zdravé jídlo 2', 'Perex 2', 'Tělo článku 2', false, 'course-zdrave-stravovani'),
+  ('article-zs-3', now(), 'seed', now(), 'seed', 'zdrave-3', 'Zdravé jídlo 3', 'Perex 3', 'Tělo článku 3', false, 'course-zdrave-stravovani')
+ON CONFLICT (id) DO UPDATE SET modified = now();
+
+-- Ensure the testmember has access to the product (user_product) so membership checks pass.
+INSERT INTO user_product (id, user_id, product_id, created)
+SELECT 'user_product-testmember-prod', u.id, p.id, now()
+FROM users u, products p
+WHERE u.login = 'testmember' AND p.id = 'prod-kurz-zdrave'
+  AND NOT EXISTS (SELECT 1 FROM user_product up WHERE up.user_id = u.id AND up.product_id = p.id);
+
+COMMIT;
+
+-- End of seed script. Safe to re-run.

--- a/scripts/seed_courses_e2e.sql
+++ b/scripts/seed_courses_e2e.sql
@@ -55,34 +55,78 @@ ALTER TABLE articles ADD COLUMN IF NOT EXISTS module_id VARCHAR(40) DEFAULT NULL
 CREATE INDEX IF NOT EXISTS idx_articles_course_id ON articles (course_id);
 CREATE INDEX IF NOT EXISTS idx_articles_module_id ON articles (module_id);
 
--- Add foreign key constraints if missing. Use plpgsql blocks to check existence first.
+-- Add foreign key constraints if missing. Use plpgsql blocks with robust existence checks
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_modules_course_id') THEN
+  -- modules.course_id -> courses.id
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_class r ON c.confrelid = r.oid
+    WHERE c.contype = 'f' AND t.relname = 'modules' AND r.relname = 'courses')
+  THEN
     ALTER TABLE modules ADD CONSTRAINT fk_modules_course_id FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE CASCADE;
   END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_product_course_product') THEN
+
+  -- product_course.product_id -> products.id
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_class r ON c.confrelid = r.oid
+    WHERE c.contype = 'f' AND t.relname = 'product_course' AND r.relname = 'products')
+  THEN
     ALTER TABLE product_course ADD CONSTRAINT fk_product_course_product FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE;
   END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_product_course_course') THEN
+
+  -- product_course.course_id -> courses.id
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_class r ON c.confrelid = r.oid
+    WHERE c.contype = 'f' AND t.relname = 'product_course' AND r.relname = 'courses')
+  THEN
     ALTER TABLE product_course ADD CONSTRAINT fk_product_course_course FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE CASCADE;
   END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_articles_course') THEN
+
+  -- articles.course_id -> courses.id
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_class r ON c.confrelid = r.oid
+    WHERE c.contype = 'f' AND t.relname = 'articles' AND r.relname = 'courses')
+  THEN
     ALTER TABLE articles ADD CONSTRAINT fk_articles_course FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE SET NULL;
   END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_articles_module') THEN
+
+  -- articles.module_id -> modules.id
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_class r ON c.confrelid = r.oid
+    WHERE c.contype = 'f' AND t.relname = 'articles' AND r.relname = 'modules')
+  THEN
     ALTER TABLE articles ADD CONSTRAINT fk_articles_module FOREIGN KEY (module_id) REFERENCES modules(id) ON DELETE SET NULL;
   END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_courses_created_by') THEN
+
+  -- courses.created_by/modified_by -> users.id
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_class r ON c.confrelid = r.oid
+    WHERE c.contype = 'f' AND t.relname = 'courses' AND r.relname = 'users')
+  THEN
     ALTER TABLE courses ADD CONSTRAINT fk_courses_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL;
-  END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_courses_modified_by') THEN
     ALTER TABLE courses ADD CONSTRAINT fk_courses_modified_by FOREIGN KEY (modified_by) REFERENCES users(id) ON DELETE SET NULL;
   END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_modules_created_by') THEN
+
+  -- modules.created_by/modified_by -> users.id
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON c.conrelid = t.oid
+    JOIN pg_class r ON c.confrelid = r.oid
+    WHERE c.contype = 'f' AND t.relname = 'modules' AND r.relname = 'users')
+  THEN
     ALTER TABLE modules ADD CONSTRAINT fk_modules_created_by FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL;
-  END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_modules_modified_by') THEN
     ALTER TABLE modules ADD CONSTRAINT fk_modules_modified_by FOREIGN KEY (modified_by) REFERENCES users(id) ON DELETE SET NULL;
   END IF;
 END$$;


### PR DESCRIPTION
Fixes #31

## Summary

Added idempotent SQL seed script enhancements for Courses E2E: ensured courses/modules include created_by/modified_by columns, added indexes and foreign key constraints for modules, product_course and articles, and added article/module indexes. Top usage comment present. Reviewed for idempotency and minimal changes.
Review: Updated existing scripts/seed_courses_e2e.sql to align with DB conventions and add referential integrity. The script is safe to re-run and creates testadmin, testmember, product, course (slug 'zdrave-stravovani'), two modules, three course-scoped articles and links testmember to the product via user_product.


## Evaluation

⚠️ Acceptance criteria not fully satisfied after 2 iteration(s):
- Criterion 1: Could not verify script is executable via psql in this environment — 'psql' client is not installed (psql: command not found). Please run: psql -U artbeams_user -d artbeams -f scripts/seed_courses_e2e.sql on a developer/database instance and confirm it exits 0 with no manual edits.
- Criterion 2: Idempotency not verified because the script could not be executed here. Static review: the script uses ON CONFLICT and WHERE NOT EXISTS in many places which suggests idempotency, but this must be validated by running the script twice and then executing: SELECT COUNT(*) FROM courses WHERE slug = 'zdrave-stravovani'; (expect 1) and SELECT COUNT(*) FROM product_course WHERE course_id = (SELECT id FROM courses WHERE slug='zdrave-stravovani'); (expect >=1). If these queries show duplicates, adjust the script to use proper ON CONFLICT targets or unique constraints that exist in the schema.
- Criterion 3: Presence of seeded rows (users, products, course, modules, articles) not verified at runtime. Static inspection shows INSERTs for 'testadmin', 'testmember', product 'Kurz zdravého stravování', course slug 'zdrave-stravovani', two modules, and three articles. Please run the following SQL after executing the script and attach outputs: 
 1) SELECT id FROM users WHERE login = 'testadmin';
 2) SELECT id FROM users WHERE login = 'testmember';
 3) SELECT id FROM products WHERE title ILIKE '%Kurz zdrav%';
 4) SELECT id FROM courses WHERE slug = 'zdrave-stravovani';
 5) SELECT id FROM modules WHERE course_id = (SELECT id FROM courses WHERE slug='zdrave-stravovani'); (expect 2 rows)
 6) SELECT id FROM articles WHERE course_id = (SELECT id FROM courses WHERE slug='zdrave-stravovani'); (expect 3 rows).
- Criterion 4: Integration check for product membership not executed here. The script inserts a user_product entry directly which should satisfy UserProductRepository checks, but please run: SELECT 1 FROM user_product WHERE user_id = (SELECT id FROM users WHERE login='testmember') AND product_id = (SELECT id FROM products WHERE title ILIKE '%Kurz zdrav%'); and confirm it returns a row. If your schema instead expects orders + order_items, either insert an order + order_item or ensure application checks user_product as membership source.
- Additional potential issues discovered by static review:
 - ALTER TABLE articles ... will fail if the 'articles' table does not exist in the target DB; ensure the script is run against the project DB where articles table already exists.
 - The script inserts a constant id into user_product ('user_product-testmember-prod'); confirm user_product has an 'id' column accepting that value and no conflicting sequences/constraints.
 - The script adds foreign key constraints with specific conname checks; if constraints with different names exist, duplicates may be created or ALTER may fail; validate on target DB.

## Code review

⚠️ Actionable review findings remained after 2 iteration(s):
- [normal/logic] Foreign-key existence checks are brittle (pg_constraint conname matching): scripts/seed_courses_e2e.sql uses a DO $$ block that checks pg_constraint.conname equality (e.g. conname = 'fk_modules_course_id') before adding FK constraints. This approach is brittle: if a matching constraint already exists under a different name the script will try to add a duplicate constraint and fail; conversely if constraints are present but with different names the script won't detect them. Replace the conname checks with robust existence checks that inspect information_schema or pg_constraint for a constraint that references the specific table/columns (for example query information_schema.table_constraints / information_schema.key_column_usage or pg_constraint referencing constraintrelid/conkey), or wrap each ALTER TABLE ... ADD CONSTRAINT in a BEGIN/EXCEPTION block to ignore 'already exists' errors. Location: scripts/seed_courses_e2e.sql (DO $$ block adding FK constraints).

---
Automation details:
- Branch: issue-31-add-idempotent-e2e-seed-script-for-cours-9ece64
- Diff stat:

```
scripts/seed_courses_e2e.sql | 160 +++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 160 insertions(+)
```