### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781611201281.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781611201281.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781611201281",
+  "planning": {
+    "input": 73853,
+    "cached_input": 412288,
+    "cache_write": 0,
+    "output": 2935,
+    "reasoning": 1984,
+    "cost": 0.038608,
+    "updated_at": "2026-06-16T12:02:23.139Z"
+  }
+}

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,14 +1,15 @@
 ## Next up (ready)
 
-- Add Course and Module domain classes and Asset-backed repository (create src/main/kotlin/org/xbery/artbeams/courses/domain/Course.kt, Module.kt and src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt; foundation for Courses feature)
+- Add Course/Module assignment into article admin editor by extending src/main/kotlin/org/xbery/artbeams/articles/domain/{Article,EditedArticle}.kt, src/main/kotlin/org/xbery/artbeams/articles/repository/mapper/*, src/main/kotlin/org/xbery/artbeams/articles/admin/{ArticleForm,ArticleAdminController}.kt, and src/main/resources/templates/admin/articles/articleEdit.ftl — enable admins to assign an Article to a Course (and optionally to a Module).
 
 
 ## Later / ideas
 <!-- To suggest work, add items to "## Later / ideas" below. The planner will promote them when capacity opens up. -->
-- Add Course/Module assignment into article admin editor by extending src/main/kotlin/org/xbery/artbeams/articles/domain/{Article,EditedArticle}.kt, src/main/kotlin/org/xbery/artbeams/articles/repository/mapper/*, src/main/kotlin/org/xbery/artbeams/articles/admin/{ArticleForm,ArticleAdminController}.kt, and src/main/resources/templates/admin/articles/articleEdit.ftl — moved to Later until Course domain/repository foundation exists.
+- (seed) Implement Course detail pages and member-side course navigation/menu, search and per-course article listing (requires Course/Module admin + article assignment). Moved to Later until admin assignment and access control are complete.
 
 ## Done (recent)
 <!-- Issues closed as completed in recent planning cycles. The planner moves items here automatically. -->
+- Add Course and Module domain classes and Asset-backed repository (src/main/kotlin/org/xbery/artbeams/courses/domain/Course.kt, Module.kt and src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt)
 
 ## Skipped (recent)
 <!-- Items the planner rejected or deferred this cycle, with a one-line rationale. -->


### PR DESCRIPTION
## Planning run
_Reconciled: the original Next up item (Add Course and Module domain classes and repository) is already implemented in the repo, so it was moved to Done. Picked: promoted the Later item about wiring Course/Module into the article admin editor because the domain/repository foundation exists and the Later entry was well-scoped with concrete file paths. Skipped: deferred full member-side UI work and E2E seed script to Later since admin assignment must land first. Risks: ensure DB schema contains articles.course_id and articles.module_id (or appropriate join tables) — database migrations may be required before runtime; if migrations are missing, the implementation should add them and run `./gradlew generateJooq` as part of work._
**Stuck/state snapshot:** 0 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Add Course/Module assignment to article admin editor** (estimate: M)

   Summary:
   Allow administrators to assign an Article to a Course and (optionally) to a Module from the existing admin article editor. This change updates the Article/EditedArticle domain types, repository mappers/unmappers, the admin form definition, controller and the articleEdit.ftl template so that courses/modules can be selected when editing or creating an article.
   
   Context: src/main/kotlin/org/xbery/artbeams/articles/domain/Article.kt, src/main/kotlin/org/xbery/artbeams/articles/domain/EditedArticle.kt, src/main/kotlin/org/xbery/artbeams/articles/repository/mapper/ArticleMapper.kt, src/main/kotlin/org/xbery/artbeams/articles/repository/mapper/ArticleUnmapper.kt, src/main/kotlin/org/xbery/artbeams/articles/admin/ArticleForm.kt, src/main/kotlin/org/xbery/artbeams/articles/admin/ArticleAdminController.kt, src/main/resources/templates/admin/articles/articleEdit.ftl
   
   ## Acceptance Criteria
   1. EditedArticle.kt adds optional properties `courseId: String?` and `moduleId: String?`; Article.kt is extended to include `courseId/moduleId` (nullable) and Article.updatedWith preserves these values from EditedArticle. (Verify by file diff.)
   2. ArticleMapper.kt maps the database record's course_id and module_id into Article.courseId and Article.moduleId; ArticleUnmapper.kt sets record.course_id/module_id from Article.courseId/moduleId. (Verify by adding a unit test at src/test/kotlin/org/xbery/artbeams/articles/repository/ArticleMapperUnmapperCourseAssignmentTest.kt that constructs a ArticlesRecord with course_id/module_id and asserts mapping/unmapping round-trip.)
   3. ArticleForm.definition (ArticleForm.kt) is extended with fields `courseId` and `moduleId` (use appropriate Field type, e.g. DROP_DOWN_CHOICE). (Verify by unit test src/test/kotlin/org/xbery/artbeams/articles/admin/ArticleFormFieldsTest.kt that asserts the form mapping contains fields named 'courseId' and 'moduleId'.)
   4. articleEdit.ftl contains select inputs bound to the form fields (example: `<select name="${fields.courseId.name}"` ), and ArticleAdminController.renderEditForm adds `courses` (and modules for the selected course) into model so template can render options. (Verify by asserting the template file contains `${fields.courseId.name}` and `${fields.moduleId.name}` strings and by an integration test that calls renderEditForm and asserts model contains 'courses'.)
   5. Manual admin check: run the application locally (./gradlew bootRun --args='--spring.profiles.active=local'), open /admin/articles/{id}/edit, confirm Course dropdown appears in the editor UI and that saving an article with a selected course persists course_id (verified by reading DB or by the mapping unit test).
   
   ## Dependencies
   (none — Course/Module domain & CourseRepository already exist in the codebase)
   
   @worker
   
   Scope: M
   
   ---
   _Grade: 5/5 | Covers: Article has possibility to be assigned to a course within existing article administration/editor. | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._