### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781613538400.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781613538400.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781613538400",
+  "planning": {
+    "input": 35995,
+    "cached_input": 156544,
+    "cache_write": 0,
+    "output": 2539,
+    "reasoning": 3136,
+    "cost": 0.024262,
+    "updated_at": "2026-06-16T12:40:46.475Z"
+  }
+}

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,14 +1,14 @@
 ## Next up (ready)
 
-- Add Course/Module assignment into article admin editor by extending src/main/kotlin/org/xbery/artbeams/articles/domain/{Article,EditedArticle}.kt, src/main/kotlin/org/xbery/artbeams/articles/repository/mapper/*, src/main/kotlin/org/xbery/artbeams/articles/admin/{ArticleForm,ArticleAdminController}.kt, and src/main/resources/templates/admin/articles/articleEdit.ftl — enable admins to assign an Article to a Course (and optionally to a Module).
+- Implement Course detail pages and member-side course navigation/menu, search and per-course article listing by creating src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt, templates under src/main/resources/templates/member/{courseDetail.ftl,moduleDetail.ftl,courseSearchResults.ftl}, updating src/main/kotlin/org/xbery/artbeams/members/controller/MemberSectionController.kt and src/main/resources/templates/member/memberSection.ftl, and guarding public article access in the public article controller — requires Course/Module admin + article assignment (already implemented).
 
 
 ## Later / ideas
 <!-- To suggest work, add items to "## Later / ideas" below. The planner will promote them when capacity opens up. -->
-- (seed) Implement Course detail pages and member-side course navigation/menu, search and per-course article listing (requires Course/Module admin + article assignment). Moved to Later until admin assignment and access control are complete.
 
 ## Done (recent)
 <!-- Issues closed as completed in recent planning cycles. The planner moves items here automatically. -->
+- Add Course/Module assignment into article admin editor by extending src/main/kotlin/org/xbery/artbeams/articles/domain/{Article,EditedArticle}.kt, src/main/kotlin/org/xbery/artbeams/articles/repository/mapper/*, src/main/kotlin/org/xbery/artbeams/articles/admin/{ArticleForm,ArticleAdminController}.kt, and src/main/resources/templates/admin/articles/articleEdit.ftl — enable admins to assign an Article to a Course (and optionally to a Module).
 - Add Course and Module domain classes and Asset-backed repository (src/main/kotlin/org/xbery/artbeams/courses/domain/Course.kt, Module.kt and src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt)
 
 ## Skipped (recent)


### PR DESCRIPTION
## Planning run
_Reconciled: moved the previously-ready admin assignment item into Done because that work was completed (recent commits and #38 completed). Picked: promoted the Later seed for member-side Course pages into Next up and created one implementation issue because Next up was empty and Course assignment is merged; this directly advances the sprint DoD (member navigation, per-course search, article access guard). Skipped: no items were skipped this run. Risks: the end-to-end verification requires either the seed script or test fixtures (seed_courses_e2e.sql is referenced) and a local DB with JOOQ classes regenerated; running the full E2E may require running ./gradlew generateJooq and applying the migration._
**Stuck/state snapshot:** 0 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Implement member-side Course pages, navigation and per-course search** (estimate: L)

   Implement member-facing Course pages and navigation so logged-in members who purchased an assigned product can browse Courses (sets of articles), view Modules and per-module article lists, and search within a Course.
   
   Context: Changes touch member and courses controllers and templates and the article access guard: src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt (new), src/main/kotlin/org/xbery/artbeams/members/controller/MemberSectionController.kt (modify), src/main/kotlin/org/xbery/artbeams/articles/controller/* (article detail handler — add access guard), and FreeMarker templates under src/main/resources/templates/member/{memberSection.ftl,courseDetail.ftl,moduleDetail.ftl,courseSearchResults.ftl}. Also call existing CourseService.findCoursesForUser(...) and ModuleService.findModulesByCourseId(...) to populate models.
   
   ## Acceptance Criteria
   1. HTTP endpoints exist: GET /clenska-sekce/kurzy/{courseSlug}, GET /clenska-sekce/kurzy/{courseSlug}/moduly/{moduleSlug}, and GET /clenska-sekce/kurzy/{courseSlug}/search?q=... implemented in CourseController and protected by loginService.requireLoggedUser(request); unauthorized requests are redirected to the login page (HTTP 302) or receive 401.
   2. MemberSectionController.memberSectionHome() adds `courses` to the model when the logged user has purchased products that map to Courses; the memberSection.ftl renders a top course menu showing each course.title linking to /clenska-sekce/kurzy/${course.slug}. Test: add unit test at src/test/kotlin/org/xbery/artbeams/members/controller/MemberSectionControllerTest.kt that stubs LoginService & CourseService and asserts model contains courses and the rendered HTML contains the course link.
   3. Course detail and module detail pages render: courseDetail.ftl shows title, description, search form and either list of modules (image,title,perex) or top-level article list when no modules; moduleDetail.ftl shows module title, perex and article list. Test: add controller unit tests at src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerTest.kt verifying 200 responses and the model contains expected `course` and `modules`/`articles` for authorized users and 403/redirect for unauthorized users.
   4. Public article detail handler enforces access: if an Article has article.courseId != null, requesting the article without membership redirects to /clenska-sekce (HTTP 302) or returns 403; add unit test at src/test/kotlin/org/xbery/artbeams/articles/controller/ArticleControllerCourseAccessTest.kt mocking ArticleRepository and CourseService to assert unauthorized access is blocked and authorized user can view the article.
   5. Course search works: GET /clenska-sekce/kurzy/{courseSlug}/search?q=term returns only articles with articles.courseId == course.id and limits results to the provided `limit` (default 50). Add an integration test at src/test/kotlin/org/xbery/artbeams/courses/service/CourseSearchIntegrationTest.kt that inserts three articles (two with the target courseId, one with different courseId/public) and asserts the search endpoint returns only the two matching course articles.
   6. End-to-end verification steps (manual or MCP-driven): Using an idempotent seed (scripts/seed_courses_e2e.sql) or test fixtures, start the app locally (./gradlew bootRun --args='--spring.profiles.active=local'), login as testmember, open http://localhost:8080/clenska-sekce, assert the course menu is visible, click a course link, open a module and an article; assert the pages show course/module/article titles and that private course articles are not accessible when logged out. Record screenshots and note any console/network errors via Chrome DevTools MCP.
   
   ## Dependencies
   - None (relies on Course/Module admin and article assignment which are already implemented and merged).
   
   @worker
   
   Scope: L
   
   ---
   _Grade: 5/5 | Covers: User with member role who purchased a product that has an assigned course can access those article sets and their articles in his member section once logged in. Member section will have simple top menu before the tiles of products (visible if some course is available). | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._