### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781625601672.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781625601672.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781625601672",
+  "planning": {
+    "input": 55907,
+    "cached_input": 577152,
+    "cache_write": 0,
+    "output": 2926,
+    "reasoning": 3328,
+    "cost": 0.040914,
+    "updated_at": "2026-06-16T16:03:06.907Z"
+  }
+}

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,6 @@
 ## Next up (ready)
 
-
--
+- Implement module loading in CourseRepository: populate Course.modules from COURSE_MODULES (see src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt). This is a small, infra-level change that removes the TODO and adds a unit test to verify modules are returned by findById.
 
 ## Later / ideas
 


### PR DESCRIPTION
## Planning run
_Reconciled: Next up was empty and Later contained a member-side pages item that is already in-progress as #41, so proposing an infra task instead. Picked: implement module-loading in CourseRepository because the source file contains an explicit TODO and ArticleAdminController depends on Course.modules; this is small and unblocks #41. Skipped: did not re-propose the already-open #41 member-pages work. Risks: the change touches JOOQ usages and tests may need lightweight mocking or regenerated jOOQ classes; worker should run ./gradlew clean build and run the new test._
**Stuck/state snapshot:** 1 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Implement module loading in CourseRepository (populate Course.modules)** (estimate: S)

   Implement module loading in CourseRepository so that CourseRepository.findById(id) returns a Course whose modules list is populated from the COURSE_MODULES table.
   
   Context: src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt (contains TODO comment about loading course_modules), src/main/kotlin/org/xbery/artbeams/courses/domain/Module.kt, and src/main/kotlin/org/xbery/artbeams/articles/admin/ArticleAdminController.kt (reads course.modules when rendering the article edit form).
   
   ## Acceptance Criteria
   1. CourseRepository.kt is updated so that findById(id) (or an internal helper) loads module rows from the COURSE_MODULES/CourseModules JOOQ table and populates the returned Course.modules list. Verify by inspecting the diff for changes to src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt that add the module-loading logic.
   2. The TODO comment string "TODO: Implement mapping logic to load course_modules rows" is removed from src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt.
   3. Add a unit test at src/test/kotlin/org/xbery/artbeams/courses/CourseRepositoryModulesTest.kt that exercises CourseRepository.findById: the test should mock the DSL/mappers (or use a lightweight in-memory setup) to return a course plus two module records and assert the returned Course.modules size is 2 and module fields (title/image) match the mocked data. Test command: ./gradlew test --tests org.xbery.artbeams.courses.CourseRepositoryModulesTest.
   4. Build succeeds: ./gradlew clean build passes (this verifies compilation with the new code).
   
   ## Dependencies
   (no external GH issue dependencies)
   
   @worker
   
   Scope: S
   
   ---
   _Grade: 5/5 | Covers: Article has possibility to be assigned to a course within existing article administration/editor. | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._