### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781798401277.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781798401277.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781798401277",
+  "planning": {
+    "input": 49191,
+    "cached_input": 400384,
+    "cache_write": 0,
+    "output": 4194,
+    "reasoning": 2368,
+    "cost": 0.035431,
+    "updated_at": "2026-06-18T16:02:38.932Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -88,7 +88,6 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-- Course and Module entities and repositories. Changes in create_tables.sql, migration script to add new tables and indexes to production. 
 - Services for Courses and Modules.
 - Script to seed end-to-end testing data for agentic evaluating of this feature, creating new user with ADMIN role and new user with MEMBER role (including their test passwords), new Product assigned with Course with Modules and related Articles.   
 - Administration of Courses and Modules.
@@ -97,3 +96,4 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Later / ideas
 
+- Implement idempotent end-to-end browser-driven smoke script that boots the app in 'local' profile, seeds DB and performs Chrome DevTools journeys (justification: automates manual E2E verification and will be used by the MCP-based evaluation).


### PR DESCRIPTION
## Planning run
_Reconciled: The repository already contains Course domain and repository stubs and jOOQ schema stubs but create_tables.sql lacks the actual tables; migrations folder contains similar scripts for other features. Picked: adding DB migrations because it's prerequisite for service, admin and member-side work (Next up). Skipped: UI and service issues for now because they depend on DB tables and codegen. Risks: developers must run './gradlew generateJooq' and remove temporary jOOQ stubs (Courses.kt/CourseModules.kt) to avoid duplicate classes; CI must run generateJooq as part of the build. SPRING NOTE: this run creates a single implementation issue (migration) per allowedThisRun=1._
**Stuck/state snapshot:** 0 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Add DB migrations and create_tables.sql entries for Courses and CourseModules** (estimate: M)

   Add PostgreSQL migration script and update the main SQL template so the Courses/CourseModules schema is present in production and in codegen source.
   
   Context: Modify src/main/resources/sql/create_tables.sql and add a new migration file at src/main/resources/sql/migrations/add_courses_and_modules.sql. After applying the migration, run ./gradlew generateJooq to regenerate jOOQ classes and remove temporary stubs under src/main/kotlin/org/xbery/artbeams/jooq/schema (e.g. Courses.kt, CourseModules.kt, records) if they conflict with generated classes.
   
   ## Acceptance Criteria
   1. src/main/resources/sql/create_tables.sql contains CREATE TABLE statements for courses and course_modules (includes columns: id, created, created_by, modified, modified_by, slug, title, subtitle, listing_image, image, perex for courses; and id, course_id, title, image, short_description, perex, sort_order for course_modules). Implementer should verify with a unit test or grep that the file contains the strings 'CREATE TABLE courses' and 'CREATE TABLE course_modules'.
   2. A new idempotent migration script is added at src/main/resources/sql/migrations/add_courses_and_modules.sql and contains the same CREATE TABLE statements plus appropriate FOREIGN KEYs and INDEXes (course_modules.course_id FK -> courses.id). The migration file must include a short header comment describing how to run it (consistent with other migration files).
   3. jOOQ code generation step succeeds: running './gradlew generateJooq' after applying migrations produces generated jOOQ classes for Courses and CourseModules and no duplicate-class conflicts occur with the temporary stubs. The repository must compile: './gradlew clean build' succeeds in local CI.
   4. Temporary jOOQ stubs under src/main/kotlin/org/xbery/artbeams/jooq/schema that were only included to allow compilation before migrations are applied are documented for removal in the migration or a TODO in the PR description (paths: src/main/kotlin/org/xbery/artbeams/jooq/schema/tables/Courses.kt and CourseModules.kt and corresponding records).
   5. A unit test is added at src/test/kotlin/org/xbery/artbeams/courses/CourseSchemaMigrationTest.kt that asserts create_tables.sql contains the two CREATE TABLE statements and that the migration file exists. This test should pass on CI.
   
   ## Dependencies
   - @worker
   
   Scope: M
_Issues created from this run will be listed as a comment on this PR once dispatched._