### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781802001568.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781802001568.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781802001568",
+  "planning": {
+    "input": 106730,
+    "cached_input": 655616,
+    "cache_write": 0,
+    "output": 2766,
+    "reasoning": 2880,
+    "cost": 0.054365,
+    "updated_at": "2026-06-18T17:02:47.023Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -88,7 +88,6 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-- Services for Courses and Modules.
 - Script to seed end-to-end testing data for agentic evaluating of this feature, creating new user with ADMIN role and new user with MEMBER role (including their test passwords), new Product assigned with Course with Modules and related Articles.   
 - Administration of Courses and Modules.
 - Article has possibility to be assigned to a Course within existing article administration/editor.


### PR DESCRIPTION
## Planning run
_Reconciled: Removed 'Services for Courses and Modules' from Next up and proposed it as the single implementation issue this run. Picked: the service-layer task because controllers (ArticleAdminController, future CourseController) already reference CourseRepository and need a stable service API; implementing services unlocks admin and member work. Skipped: admin controllers, editor UI, and seed script for now because service layer must exist first and DB migrations (#46) are still open. Risks: DB migrations (#46) are required before full integration and E2E seeding; the issue is therefore blocked by #46 to avoid wasted work._
**Stuck/state snapshot:** 1 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Implement CourseService and ModuleService (business layer)** (estimate: M)
  - Blocked by: #46

   Summary:
   Implement the Course and Module service layer to provide business APIs used by admin controllers and member-facing controllers. This adds CourseService, CourseServiceImpl, ModuleService, ModuleServiceImpl and accompanying unit tests so higher layers (admin controllers, member controllers, article assignment logic) can depend on a stable service interface.
   
   Context:
   Work happens in the courses feature package and surrounding callers: src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt (existing), src/main/kotlin/org/xbery/artbeams/courses/domain/Course.kt, src/main/kotlin/org/xbery/artbeams/courses/domain/Module.kt, src/main/kotlin/org/xbery/artbeams/articles/repository/ArticleRepository.kt, and src/main/kotlin/org/xbery/artbeams/articles/admin/ArticleAdminController.kt which already references courseRepository.findAll(). See sprint-memory.md for full plan.
   
   ## Acceptance Criteria
   1) Implement the following files and compile:
      - src/main/kotlin/org/xbery/artbeams/courses/service/CourseService.kt (interface)
      - src/main/kotlin/org/xbery/artbeams/courses/service/CourseServiceImpl.kt (impl)
      - src/main/kotlin/org/xbery/artbeams/courses/service/ModuleService.kt (interface)
      - src/main/kotlin/org/xbery/artbeams/courses/service/ModuleServiceImpl.kt (impl)
      The implementations must wire Spring @Service and use the existing CourseRepository and a new ModuleRepository (create if missing) where appropriate.
   2) Add unit tests asserting service behavior: create Kotest unit test at src/test/kotlin/org/xbery/artbeams/courses/service/CourseServiceTest.kt that uses MockK to stub CourseRepository and ArticleRepository and asserts:
      - findCoursesForUser(userId) returns the list of courses provided by repository for user's products
      - findBySlug(slug) returns repository.findBySlug result
      - searchArticlesInCourse(courseId, q, limit) calls ArticleRepository with course filtering and returns results
      The test must be executable with ./gradlew test and included in the repo.
   3) Ensure ArticleAdminController continues to compile and that renderEditForm() can obtain courses via CourseRepository (no behavior change to controller).
   4) Add one integration-style unit test that instantiates CourseServiceImpl with in-memory/mock repositories and verifies searchArticlesInCourse does not return public articles (i.e., results have courseId == expected courseId). Test path: src/test/kotlin/org/xbery/artbeams/courses/service/CourseServiceIntegrationTest.kt.
   5) Run build: ./gradlew clean build or at least ./gradlew test must pass in CI for the new tests.
   
   ## Dependencies
   - Blocked by: #46 — DB migrations for Courses and CourseModules must be applied before end-to-end integration runs against a real DB.
   
   @worker
   
   Scope: M
   
   ---
   _Grade: 5/5 | Covers: Administration of Courses is implemented, allowing administrators to create and manage Courses (sets of articles) and assign them to products, create list of modules within this course - each module with image, title, short description and perex content (introduction text). | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._