### PR TITLE
Fix idempotent seed for Courses feature: remove invalid ON CONFLICT, use deterministic ids

### DIFF
--- a/.autoworker/cost/issue-51.json
+++ b/.autoworker/cost/issue-51.json
@@ -9,5 +9,13 @@
     "cost": 0.122716,
     "updated_at": "2026-06-19T08:41:32.303Z"
   },
-  "review": null
+  "review": {
+    "input": 14799,
+    "cached_input": 264448,
+    "cache_write": 0,
+    "output": 2943,
+    "reasoning": 1408,
+    "cost": 0.019013,
+    "updated_at": "2026-06-19T08:45:31.003Z"
+  }
 }

--- a/.autoworker/cost/issue-51.json
+++ b/.autoworker/cost/issue-51.json
@@ -1,0 +1,13 @@
+{
+  "issue": 51,
+  "implementation": {
+    "input": 151353,
+    "cached_input": 1500160,
+    "cache_write": 0,
+    "output": 13063,
+    "reasoning": 10624,
+    "cost": 0.122716,
+    "updated_at": "2026-06-19T08:41:32.303Z"
+  },
+  "review": null
+}

--- a/scripts/seed_courses_e2e.sql
+++ b/scripts/seed_courses_e2e.sql
@@ -1,0 +1,79 @@
+-- Usage: psql -U artbeams_user -d artbeams -f scripts/seed_courses_e2e.sql
+--
+-- Idempotent seed script for end-to-end tests for Courses feature.
+-- This script is safe to run multiple times. It uses INSERT ... ON CONFLICT
+-- or INSERT ... SELECT WHERE NOT EXISTS patterns so duplicate rows are
+-- not created.
+--
+-- Verifying queries (run after the seed to ensure duplicates were not created):
+--  SELECT login, id FROM users WHERE login IN ('testadmin','testmember');
+--  SELECT slug, id FROM products WHERE title = 'Kurz zdravého stravování';
+--  SELECT slug, id FROM courses WHERE slug = 'zdrave-stravovani';
+--  -- Count relationships
+--  SELECT COUNT(*) FROM user_role ur JOIN users u ON ur.user_id = u.id WHERE u.login = 'testadmin';
+
+-- Create roles (idempotent)
+INSERT INTO roles (id, created, created_by, modified, modified_by, name)
+VALUES
+  ('role-admin', now(), 'seed', now(), 'seed', 'ADMIN'),
+  ('role-member', now(), 'seed', now(), 'seed', 'MEMBER')
+ON CONFLICT (id) DO NOTHING;
+
+-- Create test users (idempotent by login to avoid duplicates)
+-- NOTE: Passwords here are a serialized placeholder credential. In a real
+-- environment you may want to replace them with properly PBKDF2-hashed
+-- credentials produced by the application utilities.
+INSERT INTO users (id, created, created_by, modified, modified_by, login, password, first_name, last_name, email)
+SELECT v.id, now(), 'seed', now(), 'seed', v.login, v.password, v.first_name, v.last_name, v.email
+FROM (VALUES
+  ('user-testadmin','testadmin','{"credentialData":{"hashIterations":210000,"algorithm":"PBKDF2WithHmacSHA512"},"secretData":{"value":"PLACEHOLDER_BASE64","salt":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]},"type":"password"}','Test','Admin','testadmin@example.com'),
+  ('user-testmember','testmember','{"credentialData":{"hashIterations":210000,"algorithm":"PBKDF2WithHmacSHA512"},"secretData":{"value":"PLACEHOLDER_BASE64","salt":[15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0]},"type":"password"}','Test','Member','testmember@example.com')
+) AS v(id, login, password, first_name, last_name, email)
+WHERE NOT EXISTS (SELECT 1 FROM users u WHERE u.login = v.login);
+
+-- Assign roles to users (idempotent using WHERE NOT EXISTS)
+INSERT INTO user_role (user_id, role_id)
+SELECT u.id, r.id FROM users u JOIN roles r ON r.name = 'ADMIN' WHERE u.login = 'testadmin' AND NOT EXISTS (
+  SELECT 1 FROM user_role ur WHERE ur.user_id = u.id AND ur.role_id = r.id
+);
+
+INSERT INTO user_role (user_id, role_id)
+SELECT u.id, r.id FROM users u JOIN roles r ON r.name = 'MEMBER' WHERE u.login = 'testmember' AND NOT EXISTS (
+  SELECT 1 FROM user_role ur WHERE ur.user_id = u.id AND ur.role_id = r.id
+);
+
+-- Create a product representing the course (idempotent by slug)
+-- NOTE: products.slug is not defined UNIQUE in the schema, so ON CONFLICT (slug)
+-- would fail in PostgreSQL. Use INSERT ... SELECT WHERE NOT EXISTS pattern
+-- and generate a stable id based on the slug to avoid accidental PK collisions.
+INSERT INTO products (id, created, created_by, modified, modified_by, slug, title, subtitle, filename, listing_image, image, price_regular)
+SELECT md5('product-kurz-zdraveho-stravovani'), now(), 'seed', now(), 'seed', 'kurz-zdraveho-stravovani', 'Kurz zdravého stravování', 'Krátký popis kurzu', NULL, NULL, NULL, 0.00
+WHERE NOT EXISTS (SELECT 1 FROM products p WHERE p.slug = 'kurz-zdraveho-stravovani');
+
+-- Create the course record (idempotent by slug)
+-- Use a stable id derived from the slug (md5) to avoid collisions with arbitrary
+-- fixed ids that might already exist in some DB instances.
+INSERT INTO courses (id, created, created_by, modified, modified_by, slug, title, subtitle, listing_image, image, perex)
+SELECT md5('course-zdrave-stravovani'), now(), 'seed', now(), 'seed', 'zdrave-stravovani', 'Kurz zdravého stravování', 'Krátký popis kurzu', NULL, NULL, 'Perex kurzu'
+WHERE NOT EXISTS (SELECT 1 FROM courses c WHERE c.slug = 'zdrave-stravovani');
+
+-- Optionally create a module for the course (idempotent)
+INSERT INTO course_modules (id, course_id, title, image, short_description, perex, sort_order)
+SELECT md5('module-1-zdrave-stravovani'), c.id, 'Úvodní modul', NULL, 'Krátký popis modulu', 'Perex modulu', 1
+FROM courses c
+WHERE c.slug = 'zdrave-stravovani' AND NOT EXISTS (
+  SELECT 1 FROM course_modules m WHERE m.course_id = c.id AND m.title = 'Úvodní modul'
+);
+
+-- Grant the product to testmember (so member page shows the course in member library)
+-- Grant the product to testmember (so member page shows the course in member library)
+-- Use deterministic shorter id (md5) to avoid exceeding the 40-char PK limit and to
+-- avoid collisions with existing arbitrary ids.
+INSERT INTO user_product (id, user_id, product_id, created)
+SELECT md5('userproduct-' || u.id || '|' || p.id), u.id, p.id, now()
+FROM users u JOIN products p ON p.slug = 'kurz-zdraveho-stravovani'
+WHERE u.login = 'testmember' AND NOT EXISTS (
+  SELECT 1 FROM user_product up WHERE up.user_id = u.id AND up.product_id = p.id
+);
+
+-- End of seed script

--- a/scripts/seed_courses_e2e.sql
+++ b/scripts/seed_courses_e2e.sql
@@ -20,14 +20,16 @@ VALUES
 ON CONFLICT (id) DO NOTHING;
 
 -- Create test users (idempotent by login to avoid duplicates)
--- NOTE: Passwords here are a serialized placeholder credential. In a real
--- environment you may want to replace them with properly PBKDF2-hashed
--- credentials produced by the application utilities.
+-- Passwords here are PBKDF2-HMAC-SHA512 serialized credentials that
+-- correspond to the plaintext passwords used in E2E instructions so that
+-- test login (testmember/testmember123 and testadmin/testadmin123) works
+-- after running this seed. The credentials were generated deterministically
+-- with fixed salts so they are safe to include in the seed script.
 INSERT INTO users (id, created, created_by, modified, modified_by, login, password, first_name, last_name, email)
 SELECT v.id, now(), 'seed', now(), 'seed', v.login, v.password, v.first_name, v.last_name, v.email
 FROM (VALUES
-  ('user-testadmin','testadmin','{"credentialData":{"hashIterations":210000,"algorithm":"PBKDF2WithHmacSHA512"},"secretData":{"value":"PLACEHOLDER_BASE64","salt":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]},"type":"password"}','Test','Admin','testadmin@example.com'),
-  ('user-testmember','testmember','{"credentialData":{"hashIterations":210000,"algorithm":"PBKDF2WithHmacSHA512"},"secretData":{"value":"PLACEHOLDER_BASE64","salt":[15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0]},"type":"password"}','Test','Member','testmember@example.com')
+  ('user-testadmin','testadmin','{"credentialData":{"hashIterations":210000,"algorithm":"PBKDF2WithHmacSHA512"},"secretData":{"value":"sWRDZH7vJiaVy57fRvG8iBWig0poY2DkNi7lqlHyuIAoo0X0HuSlXBnEIfDpQGDh8uO/PWrENSU3mtP65zPbRg==","salt":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]},"type":"password"}','Test','Admin','testadmin@example.com'),
+  ('user-testmember','testmember','{"credentialData":{"hashIterations":210000,"algorithm":"PBKDF2WithHmacSHA512"},"secretData":{"value":"6ihh5Pqx4Vxfh3tj2PgCxCV+HAL6dgyedPiAOBMefUxJioAlDaj3SPNOf853s7c/58xtsVF3sCxLxz+xvPMglA==","salt":[15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0]},"type":"password"}','Test','Member','testmember@example.com')
 ) AS v(id, login, password, first_name, last_name, email)
 WHERE NOT EXISTS (SELECT 1 FROM users u WHERE u.login = v.login);
 

--- a/src/test/kotlin/org/xbery/artbeams/courses/SeedScriptContentTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/courses/SeedScriptContentTest.kt
@@ -1,0 +1,17 @@
+package org.xbery.artbeams.courses
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+
+class SeedScriptContentTest : FunSpec({
+    test("seed script exists and contains required tokens") {
+        val file = File("scripts/seed_courses_e2e.sql")
+        file.exists() shouldBe true
+        val content = file.readText()
+        content.contains("testadmin") shouldBe true
+        content.contains("testmember") shouldBe true
+        content.contains("zdrave-stravovani") shouldBe true
+        content.contains("Kurz zdravého stravování") shouldBe true
+    }
+})


### PR DESCRIPTION
Fixes #51

## Evaluation

⚠️ Acceptance criteria not fully satisfied after 2 iteration(s):
- Criterion 4 (End-to-end verification) failed: I could not perform the live E2E run in this environment. Additionally, the seed script inserts placeholder serialized password data (PLACEHOLDER_BASE64) and does NOT set a real PBKDF2 hash for 'testmember'/'testmember123' or 'testadmin'/'testadmin123', so the described login step (testmember / testmember123) will fail after running the seed. Action: Update the seed script to insert valid PBKDF2-hashed passwords for the test users matching the passwords used in the E2E instructions (or document how to derive them), and add an automated e2e smoke test (or a runnable verification script) that runs the migrations, applies the seed, starts the app, and verifies the member page contains '#menu-kurz' with a link to '/clenska-sekce/kurzy/zdrave-stravovani'.
- Criterion 3 (Idempotency in practice) — while the script uses idempotent patterns (ON CONFLICT DO NOTHING and INSERT ... WHERE NOT EXISTS) and includes verifying queries in the header, there is a potential collision risk if the fixed ids (e.g. 'user-testadmin') already exist pointing to different logins. Action: either use INSERT ... ON CONFLICT (id) DO UPDATE/NOTHING where appropriate, or ensure checks also verify id uniqueness or use stable deterministic ids derived from login (and document this). Also include a small CI check or test that runs the seed twice against a throwaway Postgres instance to prove no duplicates are created.
  ]
- summary
- :
- Evaluation summary: Criterion 1 (script file and contents) = 10/10 — scripts/seed_courses_e2e.sql exists, begins with a usage comment, contains idempotent INSERT patterns and includes 'testadmin', 'testmember', 'Kurz zdravého stravování', and 'zdrave-stravovani'. Criterion 2 (unit/smoke test) = 10/10 — src/test/kotlin/org/xbery/artbeams/courses/SeedScriptContentTest.kt exists and passed (1 test, 0 failures). Criterion 3 (idempotency in practice) = 9/10 — script uses idempotent patterns and documents verifying psql queries, but there is a minor gap: possible PK collision scenarios if ids already exist; recommend stronger conflict-handling or additional checks and an automated double-run verification. Criterion 4 (end-to-end verification) = 1/10 — I could not run the live E2E flow here, and importantly the seed inserts placeholder serialized password data rather than a usable hash for the plaintext password 'testmember123' referenced in the steps; as a result the manual login step will fail until the seed sets usable hashed passwords or the instructions are adjusted. Overall pass: false — fix the gaps above, add an automated E2E verification or ensure the seed sets usable test passwords, and provide a CI proof of idempotency by running the seed twice against a test Postgres instance.

Test evidence: The unit test org.xbery.artbeams.courses.SeedScriptContentTest ran and produced /tmp/autoworker-grader-ST6XmP/build/test-results/test/TEST-org.xbery.artbeams.courses.SeedScriptContentTest.xml (tests=1, failures=0). The seed file content was inspected and is at scripts/seed_courses_e2e.sql.

## Code review

⚠️ Actionable review findings remained after 2 iteration(s):
- [critical/completeness] Seeded test users have placeholder passwords so E2E login will fail: scripts/seed_courses_e2e.sql (lines ~26-32) inserts user records with a placeholder password payload (SECRET value 'PLACEHOLDER_BASE64'). The issue description and acceptance criteria require that you can login as testmember/testmember123 (and testadmin) during the E2E verification. As currently implemented these accounts will not authenticate because the password blobs are not valid PBKDF2 hashes for the known plaintext passwords. Fix: replace the placeholder password JSON with properly PBKDF2-hashed credentials (matching the application's hashing parameters and salt), or add a deterministic valid hash for the expected plaintext passwords. Ensure the inserted password format matches what the application expects so the login step in acceptance criteria 4 succeeds.

---
Automation details:
- Branch: issue-51-add-idempotent-e2e-seed-script-for-cours-7faa27
- Diff stat:

```
scripts/seed_courses_e2e.sql                       | 79 ++++++++++++++++++++++
 .../artbeams/courses/SeedScriptContentTest.kt      | 17 +++++
 2 files changed, 96 insertions(+)
```