### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781877601350.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781877601350.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781877601350",
+  "planning": {
+    "input": 61177,
+    "cached_input": 453888,
+    "cache_write": 0,
+    "output": 4530,
+    "reasoning": 3648,
+    "cost": 0.042997,
+    "updated_at": "2026-06-19T14:03:06.756Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -88,11 +88,8 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-- Script to seed end-to-end testing data for agentic evaluating of this feature, creating new user with ADMIN role and new user with MEMBER role (including their test passwords), new Product assigned with Course with Modules and related Articles.
-- Administration of Courses and Modules.
-- Article has possibility to be assigned to a Course within existing article administration/editor.
-- Member section enhanced with Courses (and their inner Modules and Articles within them).
+- Implement idempotent end-to-end browser-driven smoke script that boots the app in 'local' profile, seeds DB (scripts/seed_courses_e2e.sql) and performs Chrome DevTools MCP journeys that log in as `testmember`, verify the course menu (nav.course-menu), visit `/clenska-sekce/zdrave-stravovani` and assert module/article lists. (Grounding: scripts/seed_courses_e2e.sql, start.sh, sprint-memory.md Task 7.)
 
 ## Later / ideas
 
-- Implement idempotent end-to-end browser-driven smoke script that boots the app in 'local' profile, seeds DB and performs Chrome DevTools journeys (justification: automates manual E2E verification and will be used by the MCP-based evaluation).
+- (none)


### PR DESCRIPTION
## Planning run
_Reconciled: input Next-up items were reviewed and several are already implemented in recent commits (see closed issues #35, #38, #46, #48, #51). Picked: the E2E smoke-script from Later because it's well-grounded (scripts/seed_courses_e2e.sql exists) and is the missing piece to programmatically verify the sprint DoD with MCP journeys. Skipped: re-proposing admin/service/article-assignment work because those topics are completed per repo history. Risks: the script depends on a local Postgres instance and a free port for the app; the wrapper must wait robustly for the app to be ready. Next: worker will create scripts/e2e/run_smoke_courses.sh and scripts/e2e/smoke_courses_mcp.js and add brief README and artifacts directory._
**Stuck/state snapshot:** 0 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Add idempotent E2E smoke script (Chrome DevTools) for Courses** (estimate: M)

   Add an idempotent, agent-driven end-to-end smoke test that boots the app in the local profile, seeds the Courses test data, and performs a Chrome DevTools (MCP) browser journey verifying member access to a seeded Course.
   
   Context: scripts/seed_courses_e2e.sql, start.sh, ./gradlew bootRun, sprint-memory.md (Tasks 6–7), member/memberSection.ftl (nav injection), admin/users/login.ftl (login form selectors).
   
   ## Acceptance Criteria
   
   1. A runnable wrapper script is added at scripts/e2e/run_smoke_courses.sh that:
      - Executes the SQL seed at scripts/seed_courses_e2e.sql against the local DB (psql invocation documented in sprint-memory.md).
      - Starts the application with ./gradlew bootRun --args='--spring.profiles.active=local' (or uses start.sh) in the background and waits until http://localhost:8080/ responds 200.
      - Runs a browser-driven script scripts/e2e/smoke_courses_mcp.js (or .py) that performs the MCP journey below.
      - Stops the application and exits with code 0 on success.
   
   2. A browser-driven script is added at scripts/e2e/smoke_courses_mcp.js that implements the Chrome DevTools MCP journey and saves screenshots to scripts/e2e/artifacts/:
      - Navigate to http://localhost:8080/login, fill input#username with "testmember" and input#password with "testmember123", submit the form.
      - Wait for navigation and then navigate to http://localhost:8080/clenska-sekce.
      - Assert that a course menu is present: element `nav.course-menu` exists and contains a link to the seeded course slug `zdrave-stravovani` (anchor href `/clenska-sekce/zdrave-stravovani`).
      - Click the course link, wait for the course detail page, assert the presence of either `.module-list` or `.article-list` (one of them must be present) and take a screenshot `artifacts/course-detail.png`.
      - On failure, save a screenshot and exit non-zero.
   
   3. The wrapper script is idempotent: running scripts/e2e/run_smoke_courses.sh repeatedly does not create duplicate users or products. The script verifies idempotence by executing SQL checks after the seed and before exit:
      - `SELECT COUNT(*) FROM users WHERE login = 'testmember'` returns 1
      - `SELECT COUNT(*) FROM products WHERE slug = 'kurz-zdraveho-stravovani'` >= 1
   
   4. Programmatic verification: invoking scripts/e2e/run_smoke_courses.sh returns exit code 0 and produces screenshots in scripts/e2e/artifacts/ (at least `course-detail.png`). Include example command in the script header and a README note at scripts/e2e/README.md.
   
   ## Dependencies
   
   - none (uses existing seed script at scripts/seed_courses_e2e.sql and local dev run commands).
   
   @worker
   
   Scope: M
   
   
   ---
   _Grade: 5/5 | Covers: End-to-end test the complete application by running it locally, with idempotent seed script for filling all data needed
   to be present in database for full testing. Use Chrome DevTools MCP tools for evaluation
   of all the user journeys like the humans do through the typing, clicking, seeing (taking screenshots),
   observing application logs and errors, network traffic and console errors in the browser. | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._