### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781881201870.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781881201870.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781881201870",
+  "planning": {
+    "input": 56337,
+    "cached_input": 488960,
+    "cache_write": 0,
+    "output": 5103,
+    "reasoning": 2432,
+    "cost": 0.041378,
+    "updated_at": "2026-06-19T15:02:45.725Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -88,7 +88,8 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-- (none)
+- Implement Courses admin CRUD and templates (admin/courses): add CourseAdminController, ModuleAdminController, CourseForm, ModuleForm, and templates under src/main/resources/templates/admin/courses; add "Courses" link to admin layout. This directly addresses the unmet DoD bullet: "Administration of Courses is implemented..." and will provide the admin UI required before member-side pages.
+
 
 ## Later / ideas
 


### PR DESCRIPTION
## Planning run
_Reconciled: sprint-state shows backend Course domain/repo/service and article editor changes are already implemented, but the admin UI and templates are missing (the verifier marked unmet DoD bullets). Picked: implement Courses admin CRUD and templates because it directly satisfies the top-priority DoD failure (Administration of Courses is implemented) and unlocks downstream member-side work. Skipped: member-side Course pages and per-course search for now because they depend on admin-created data and should follow once admin CRUD is available. Risks: templates must follow adminLayout.ftl conventions (we add a nav link); ensure tests mock CourseService to avoid DB dependency._
**Stuck/state snapshot:** 0 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Implement Courses admin CRUD and templates (admin/courses)** (estimate: L)

   Implement Courses admin CRUD and templates
   
   Summary
   Implement the administrative UI and controllers for managing Courses and Modules so administrators can create/edit/delete Courses, assign Courses to Products, and manage Modules within a Course. This provides the missing admin surface required by the sprint DoD: "Administration of Courses is implemented...".
   
   Context
   - Backend pieces already exist: src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt and src/main/kotlin/org/xbery/artbeams/courses/service/CourseServiceImpl.kt. Article editor already contains course/module select elements in src/main/resources/templates/admin/articles/articleEdit.ftl and related form code.
   - Files to add/modify by this issue:
     - Create: src/main/kotlin/org/xbery/artbeams/courses/admin/CourseAdminController.kt
     - Create: src/main/kotlin/org/xbery/artbeams/courses/admin/CourseForm.kt
     - Create: src/main/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminController.kt
     - Create: src/main/kotlin/org/xbery/artbeams/courses/admin/ModuleForm.kt
     - Create templates: src/main/resources/templates/admin/courses/courseList.ftl, courseEdit.ftl, moduleList.ftl, moduleEdit.ftl
     - Modify admin layout: src/main/resources/templates/adminLayout.ftl — add "Courses" link to the main admin nav
   
   ## Acceptance Criteria
   1. CourseAdminController provides at minimum these endpoints: GET /admin/courses (list), GET /admin/courses/edit (new/edit form), POST /admin/courses/save (create/update), POST /admin/courses/delete. ModuleAdminController provides list/edit/save/delete under /admin/courses/{courseId}/modules. Controllers use existing CourseService/ModuleService implementations.
   
   2. Templates are present at src/main/resources/templates/admin/courses/courseList.ftl and courseEdit.ftl and render the list and edit form respectively. The edit form includes a multi-select control for assigning Products to the Course (product ids), matching sprint-memory Task 5. Verify by reading the template files in tests.
   
   3. Add a simple integration test at src/test/kotlin/org/xbery/artbeams/courses/admin/CourseAdminControllerTest.kt that uses MockMvc (or equivalent project test helpers) to assert:
      - GET /admin/courses as an authenticated ADMIN returns HTTP 200 and the model contains attribute "courses" (or view name "admin/courses/courseList").
      - POST /admin/courses/save with valid CourseForm parameters invokes CourseService.saveCourse(...) and redirects to the course list (HTTP 302). The test can mock CourseService and verify interaction.
   
   4. Add an automated template-presence test: src/test/kotlin/org/xbery/artbeams/courses/admin/CourseAdminTemplatesExistTest.kt which asserts that the four template files exist on disk at the paths listed in Context. This prevents regressions where templates are missing.
   
   5. Update src/main/resources/templates/adminLayout.ftl to add a "Courses" nav item pointing to /admin/courses. Verify via a unit test that adminLayout.ftl contains the link string "/admin/courses" (add to CourseAdminTemplatesExistTest or separate test).
   
   6. Manual verification steps (end-to-end smoke): Run the app locally (./gradlew bootRun --args='--spring.profiles.active=local'), login as an ADMIN user from the e2e seed script, open /admin/courses, create a Course assigned to a Product, create two Modules for the course, and confirm they appear in the admin list. Document the manual steps in the PR description.
   
   ## Dependencies
   - None (backend service and repository code exist in this repo and are already implemented in prior commits). 
   
   @worker
   
   Scope: L
   
   
   ---
   _Grade: 5/5 | Covers: Administration of Courses is implemented, allowing administrators to create and manage Courses (sets of articles) and assign them to products, create list of modules within this course - each module with image, title, short description and perex content (introduction text). | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._