### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781884801716.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781884801716.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781884801716",
+  "planning": {
+    "input": 47998,
+    "cached_input": 423424,
+    "cache_write": 0,
+    "output": 4744,
+    "reasoning": 3264,
+    "cost": 0.038601,
+    "updated_at": "2026-06-19T16:03:07.904Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -88,7 +88,7 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-- Implement Courses admin CRUD and templates (admin/courses): add CourseAdminController, ModuleAdminController, CourseForm, ModuleForm, and templates under src/main/resources/templates/admin/courses; add "Courses" link to admin layout. This directly addresses the unmet DoD bullet: "Administration of Courses is implemented..." and will provide the admin UI required before member-side pages.
+- Implement member-facing Course pages, menu integration and per-course search: add src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt, update src/main/kotlin/org/xbery/artbeams/members/controller/MemberSectionController.kt to include courses in the model, and add FreeMarker templates under src/main/resources/templates/member/courses (list.ftl, detail.ftl, module.ftl). Add unit tests in src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerTest.kt and src/test/kotlin/org/xbery/artbeams/members/controller/MemberSectionControllerTest.kt; verify end-to-end with scripts/e2e/run_smoke_courses.sh. This addresses the unmet DoD bullets: member access, menu, per-course search and end-to-end verification.
 
 
 ## Later / ideas


### PR DESCRIPTION
## Planning run
_Reconciled: removed the admin-admin CRUD entry from Next up because that work is already in-progress (#59). Picked: a single high-leverage task that addresses the remaining unmet DoD bullets for member access, menu integration and per-course search. Skipped: re-adding admin CRUD (in-flight). Risks: ModuleRepository currently returns emptyList() (src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt); UI will render empty modules until module loading is implemented — tests should stub ModuleService where needed._
**Stuck/state snapshot:** 1 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Implement member-facing Course pages, menu and per-course search** (estimate: L)

   Enable member-facing Course pages, menu and per-course search
   
   Context: Add a member-facing controller and templates to serve Courses under the member section. Files to change/add:
   - src/main/kotlin/org/xbery/artbeams/members/controller/MemberSectionController.kt (add courses list to model)
   - Add src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt
   - Templates under src/main/resources/templates/member/courses/
     - list.ftl (course listing /clenska-sekce/courses)
     - detail.ftl (course detail with modules and per-course search form)
     - module.ftl (module listing of articles)
   - Use existing service API: org.xbery.artbeams.courses.service.CourseService (searchArticlesInCourse, findCoursesForUser, findBySlug)
   
   ## Acceptance Criteria
   1. When a logged-in member visits /clenska-sekce the model returned by MemberSectionController.memberSectionHome contains an attribute "courses" (List<Course>) for courses available to the user. Test: add/modify unit test at src/test/kotlin/org/xbery/artbeams/members/controller/MemberSectionControllerTest.kt that stubs CourseService and asserts model["courses"] is non-null.
   2. Implement CourseController with routes:
      - GET /clenska-sekce/courses -> renders template member/courses/list.ftl with model {"courses": List<Course>}.
      - GET /clenska-sekce/courses/{slug} -> renders member/courses/detail.ftl for the course (uses CourseService.findBySlug(slug)).
      - GET /clenska-sekce/courses/{slug}/modules/{moduleSlug} -> renders member/courses/module.ftl listing articles for that module.
      - POST /clenska-sekce/courses/{slug}/search (or GET with query param) -> uses CourseService.searchArticlesInCourse(courseId, q, limit) and returns filtered article list.
      Test: add unit tests in src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerTest.kt that mock CourseService and ArticleRepository to assert correct templates and model attributes.
   3. The per-course search must use CourseService.searchArticlesInCourse so results never include publicly indexed articles. Test: unit test asserts CourseService.searchArticlesInCourse is invoked and returned articles all have courseId equal to the course being searched.
   4. Add FreeMarker templates under src/main/resources/templates/member/courses that follow project styling and include HTML id attributes used by E2E (menu container id="menu-kurz", course list container id="course-list", module list id="module-list"). Smoke E2E: running scripts/e2e/run_smoke_courses.sh must complete successfully and produce artifacts/scripts/e2e/artifacts/course-detail.png (this script already exists in repo). The end-to-end journey should: start app with ./start.sh, seed DB with scripts/seed_courses_e2e.sql, navigate to /clenska-sekce, assert menu with id #menu-kurz contains at least one course link, click course link, assert course detail page shows id #course-list and at least one module or article, click article and assert article detail shows article title element.
   5. Security: verify that an unauthenticated request to any /clenska-sekce/courses* endpoints is redirected to login (use existing security config). Unit/integration test should assert GET /clenska-sekce/courses returns 302 when no session is present.
   
   ## Dependencies
   - None (relies on existing CourseService and Course domain classes already present in codebase).
   
   @worker
   Scope: L
   
   
   ---
   _Grade: 5/5 | Covers: User with member role who purchased a product that has an assigned course can access those article sets and their articles in his member section once logged in. Member section will have simple top menu before the tiles of products (visible if some course is available). | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._