### PR TITLE
Member-facing courses: controller, templates, auth and tests

### DIFF
--- a/.autoworker/cost/issue-61.json
+++ b/.autoworker/cost/issue-61.json
@@ -1,0 +1,13 @@
+{
+  "issue": 61,
+  "implementation": {
+    "input": 221124,
+    "cached_input": 2463104,
+    "cache_write": 0,
+    "output": 23016,
+    "reasoning": 13824,
+    "cost": 0.190539,
+    "updated_at": "2026-06-19T16:20:05.702Z"
+  },
+  "review": null
+}

--- a/.autoworker/cost/issue-61.json
+++ b/.autoworker/cost/issue-61.json
@@ -9,5 +9,13 @@
     "cost": 0.190539,
     "updated_at": "2026-06-19T16:20:05.702Z"
   },
-  "review": null
+  "review": {
+    "input": 57520,
+    "cached_input": 1150208,
+    "cache_write": 0,
+    "output": 6015,
+    "reasoning": 3072,
+    "cost": 0.061309,
+    "updated_at": "2026-06-19T16:29:46.417Z"
+  }
 }

--- a/src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt
@@ -1,0 +1,79 @@
+package org.xbery.artbeams.courses.controller
+
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.servlet.ModelAndView
+import jakarta.servlet.http.HttpServletRequest
+import org.xbery.artbeams.common.controller.BaseController
+import org.xbery.artbeams.common.controller.ControllerComponents
+import org.xbery.artbeams.courses.service.CourseService
+
+/**
+ * Member-facing courses controller.
+ */
+@Controller
+class CourseController(
+    private val courseService: CourseService,
+    common: ControllerComponents
+) : BaseController(common) {
+
+    @GetMapping("/clenska-sekce/courses")
+    fun listCourses(request: HttpServletRequest): Any {
+        val model = createModel(request)
+        val loggedUser = model["_loggedUser"] as? org.xbery.artbeams.users.domain.User
+            ?: return redirect("/login")
+        val courses = courseService.findCoursesForUser(loggedUser.common.id)
+        model["courses"] = courses
+        return ModelAndView("member/courses/list", model)
+    }
+
+    @GetMapping("/clenska-sekce/courses/{slug}")
+    fun courseDetail(request: HttpServletRequest, @PathVariable slug: String): Any {
+        val model = createModel(request)
+        val loggedUser = model["_loggedUser"] as? org.xbery.artbeams.users.domain.User
+            ?: return redirect("/login")
+        val course = courseService.findBySlug(slug) ?: return notFound(request)
+        model["course"] = course
+        return ModelAndView("member/courses/detail", model)
+    }
+
+    @GetMapping("/clenska-sekce/courses/{slug}/modules/{moduleSlug}")
+    fun moduleView(request: HttpServletRequest, @PathVariable slug: String, @PathVariable moduleSlug: String): Any {
+        val model = createModel(request)
+        val loggedUser = model["_loggedUser"] as? org.xbery.artbeams.users.domain.User
+            ?: return redirect("/login")
+        val course = courseService.findBySlug(slug) ?: return notFound(request)
+        val module = course.modules.find { it.id == moduleSlug }
+            ?: return notFound(request)
+        // For module articles we delegate to per-course search but filter by module id
+        val allArticles = courseService.searchArticlesInCourse(course.common.id, "", 100)
+        val articles = allArticles.filter { it.moduleId == module.id }
+        model["course"] = course
+        model["module"] = module
+        model["articles"] = articles
+        return ModelAndView("member/courses/module", model)
+    }
+
+    /**
+     * Per-course search — uses CourseService.searchArticlesInCourse to ensure only course-bound
+     * (non-public) articles are returned.
+     */
+    @RequestMapping(value = ["/clenska-sekce/courses/{slug}/search"], method = [RequestMethod.GET, RequestMethod.POST])
+    fun searchInCourse(request: HttpServletRequest, @PathVariable slug: String): Any {
+        val model = createModel(request)
+        val loggedUser = model["_loggedUser"] as? org.xbery.artbeams.users.domain.User
+            ?: return redirect("/login")
+        val course = courseService.findBySlug(slug) ?: return notFound(request)
+        val q = request.getParameter("q") ?: ""
+        val limit = try {
+            request.getParameter("limit")?.toInt() ?: 50
+        } catch (e: NumberFormatException) {
+            50
+        }
+        val articles = courseService.searchArticlesInCourse(course.common.id, q, limit)
+        model["course"] = course
+        model["q"] = q
+        model["articles"] = articles
+        return ModelAndView("member/courses/detail", model)
+    }
+}

--- a/src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt
@@ -1,12 +1,15 @@
 package org.xbery.artbeams.courses.controller
 
 import org.springframework.stereotype.Controller
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.servlet.ModelAndView
-import jakarta.servlet.http.HttpServletRequest
 import org.xbery.artbeams.common.controller.BaseController
 import org.xbery.artbeams.common.controller.ControllerComponents
 import org.xbery.artbeams.courses.service.CourseService
+import jakarta.servlet.http.HttpServletRequest
 
 /**
  * Member-facing courses controller.
@@ -33,6 +36,12 @@ class CourseController(
         val loggedUser = model["_loggedUser"] as? org.xbery.artbeams.users.domain.User
             ?: return redirect("/login")
         val course = courseService.findBySlug(slug) ?: return notFound(request)
+        // Ensure the logged user has access to this course
+        val userCourses = courseService.findCoursesForUser(loggedUser.common.id)
+        model["courses"] = userCourses
+        if (userCourses.none { it.common.id == course.common.id }) {
+            return notFound(request)
+        }
         model["course"] = course
         return ModelAndView("member/courses/detail", model)
     }
@@ -43,6 +52,11 @@ class CourseController(
         val loggedUser = model["_loggedUser"] as? org.xbery.artbeams.users.domain.User
             ?: return redirect("/login")
         val course = courseService.findBySlug(slug) ?: return notFound(request)
+        val userCourses = courseService.findCoursesForUser(loggedUser.common.id)
+        model["courses"] = userCourses
+        if (userCourses.none { it.common.id == course.common.id }) {
+            return notFound(request)
+        }
         val module = course.modules.find { it.id == moduleSlug }
             ?: return notFound(request)
         // For module articles we delegate to per-course search but filter by module id
@@ -64,6 +78,11 @@ class CourseController(
         val loggedUser = model["_loggedUser"] as? org.xbery.artbeams.users.domain.User
             ?: return redirect("/login")
         val course = courseService.findBySlug(slug) ?: return notFound(request)
+        val userCourses = courseService.findCoursesForUser(loggedUser.common.id)
+        model["courses"] = userCourses
+        if (userCourses.none { it.common.id == course.common.id }) {
+            return notFound(request)
+        }
         val q = request.getParameter("q") ?: ""
         val limit = try {
             request.getParameter("limit")?.toInt() ?: 50

--- a/src/main/kotlin/org/xbery/artbeams/members/controller/MemberSectionController.kt
+++ b/src/main/kotlin/org/xbery/artbeams/members/controller/MemberSectionController.kt
@@ -18,6 +18,7 @@ import jakarta.servlet.http.HttpServletRequest
 class MemberSectionController(
     private val userProductService: UserProductService,
     private val orderService: OrderService,
+    private val courseService: org.xbery.artbeams.courses.service.CourseService,
     common: ControllerComponents
 ) : BaseController(common) {
 
@@ -28,6 +29,12 @@ class MemberSectionController(
             request,
             "userProducts" to userProducts
         )
+        // Add courses available for the logged user to the model (if logged in)
+        val loggedUser = model["_loggedUser"] as? org.xbery.artbeams.users.domain.User
+        if (loggedUser != null) {
+            val courses = courseService.findCoursesForUser(loggedUser.common.id)
+            model["courses"] = courses
+        }
         return ModelAndView("member/memberSection", model)
     }
 

--- a/src/main/resources/templates/member/courses/detail.ftl
+++ b/src/main/resources/templates/member/courses/detail.ftl
@@ -1,0 +1,40 @@
+<#-- Course detail with modules and search form -->
+<div id="menu-kurz">
+    <h2>Kurzy</h2>
+    <ul>
+        <#if courses?has_content>
+            <#list courses as c>
+                <li><a href="/clenska-sekce/courses/${c.slug}">${c.title}</a></li>
+            </#list>
+        </#if>
+    </ul>
+</div>
+
+<div class="container">
+    <h1>${course.title}</h1>
+    <p>${course.perex}</p>
+
+    <form action="/clenska-sekce/courses/${course.slug}/search" method="get">
+        <input type="text" name="q" value="${q!}" placeholder="Hledat v kurzu" />
+        <button type="submit">Hledat</button>
+    </form>
+
+    <div id="course-list">
+        <#if articles?has_content>
+            <ul>
+            <#list articles as a>
+                <li><a href="/a/${a.slug}">${a.title}</a></li>
+            </#list>
+            </ul>
+        <#else>
+            <p>Žádné články.</p>
+        </#if>
+    </div>
+
+    <h2>Moduly</h2>
+    <ul>
+        <#list course.modules as m>
+            <li><a href="/clenska-sekce/courses/${course.slug}/modules/${m.id}">${m.title}</a></li>
+        </#list>
+    </ul>
+</div>

--- a/src/main/resources/templates/member/courses/list.ftl
+++ b/src/main/resources/templates/member/courses/list.ftl
@@ -1,0 +1,30 @@
+<#-- Member courses list -->
+<div id="menu-kurz">
+    <h2>Kurzy</h2>
+    <ul id="course-list">
+    <#if courses?has_content>
+        <#list courses as course>
+            <li><a href="/clenska-sekce/courses/${course.slug}">${course.title}</a></li>
+        </#list>
+    <#else>
+        <li>Žádné kurzy</li>
+    </#if>
+    </ul>
+</div>
+
+<#-- simple listing tiles -->
+<div class="container">
+    <h1>Moje kurzy</h1>
+    <div class="row">
+        <#if courses?has_content>
+            <#list courses as course>
+                <div class="col-md-4">
+                    <h3><a href="/clenska-sekce/courses/${course.slug}">${course.title}</a></h3>
+                    <p>${course.perex}</p>
+                </div>
+            </#list>
+        <#else>
+            <p>Prozatím nemáte žádné kurzy.</p>
+        </#if>
+    </div>
+</div>

--- a/src/main/resources/templates/member/courses/module.ftl
+++ b/src/main/resources/templates/member/courses/module.ftl
@@ -1,0 +1,28 @@
+<#-- Module view listing articles for a module -->
+<div id="menu-kurz">
+    <h2>Kurzy</h2>
+    <ul>
+        <#if courses?has_content>
+            <#list courses as c>
+                <li><a href="/clenska-sekce/courses/${c.slug}">${c.title}</a></li>
+            </#list>
+        </#if>
+    </ul>
+</div>
+
+<div class="container">
+    <h1>${course.title} — ${module.title}</h1>
+    <p>${module.perex}</p>
+
+    <div id="module-list">
+        <#if articles?has_content>
+            <ul>
+                <#list articles as a>
+                    <li><a href="/a/${a.slug}">${a.title}</a></li>
+                </#list>
+            </ul>
+        <#else>
+            <p>Žádné články v modulu.</p>
+        </#if>
+    </div>
+</div>

--- a/src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerTest.kt
@@ -5,104 +5,168 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import jakarta.servlet.http.HttpServletRequest
+import org.xbery.artbeams.articles.domain.Article
+import org.xbery.artbeams.common.assets.domain.AssetAttributes
+import org.xbery.artbeams.common.assets.domain.Validity
 import org.xbery.artbeams.common.controller.ControllerComponents
 import org.xbery.artbeams.courses.domain.Course
 import org.xbery.artbeams.courses.domain.Module
 import org.xbery.artbeams.courses.service.CourseService
 import org.xbery.artbeams.users.domain.User
-import org.xbery.artbeams.common.assets.domain.AssetAttributes
-import org.xbery.artbeams.articles.domain.Article
-import org.xbery.artbeams.common.assets.domain.Validity
 import java.time.Instant
+import jakarta.servlet.http.HttpServletRequest
 
-class CourseControllerTest : StringSpec({
+class CourseControllerTest :
+    StringSpec({
 
-    "list courses view contains courses model" {
-        val courseService = mockk<CourseService>()
-        val components = mockk<ControllerComponents>(relaxed = true)
-        val request = mockk<HttpServletRequest>(relaxed = true)
+        "list courses view contains courses model" {
+            val courseService = mockk<CourseService>()
+            val components = mockk<ControllerComponents>(relaxed = true)
+            val request = mockk<HttpServletRequest>(relaxed = true)
 
-        val now = Instant.now()
-        val userAttrs = AssetAttributes("u-id", now, "u-id", now, "u-id")
-        val user = User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
-        every { components.getLoggedUser(request) } returns user
+            val now = Instant.now()
+            val userAttrs = AssetAttributes("u-id", now, "u-id", now, "u-id")
+            val user = User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
+            every { components.getLoggedUser(request) } returns user
 
-        val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
-        val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(Module("m1", "Mod", null, null, null)))
-        every { courseService.findCoursesForUser(user.common.id) } returns listOf(course)
+            val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
+            val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(Module("m1", "Mod", null, null, null)))
+            every { courseService.findCoursesForUser(user.common.id) } returns listOf(course)
 
-        val controller = CourseController(courseService, components)
-        val mv = controller.listCourses(request) as org.springframework.web.servlet.ModelAndView
-        mv.viewName shouldBe "member/courses/list"
-        (mv.model["courses"] as List<*>).size shouldBe 1
-    }
+            val controller = CourseController(courseService, components)
+            val mv = controller.listCourses(request) as org.springframework.web.servlet.ModelAndView
+            mv.viewName shouldBe "member/courses/list"
+            (mv.model["courses"] as List<*>).size shouldBe 1
+        }
 
-    "search in course invokes course service and returns articles" {
-        val courseService = mockk<CourseService>()
-        val components = mockk<ControllerComponents>(relaxed = true)
-        val request = mockk<HttpServletRequest>(relaxed = true)
+        "search in course invokes course service and returns articles" {
+            val courseService = mockk<CourseService>()
+            val components = mockk<ControllerComponents>(relaxed = true)
+            val request = mockk<HttpServletRequest>(relaxed = true)
 
-        val now = Instant.now()
-        val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
-        val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(Module("m1", "Mod", null, null, null)))
-        every { courseService.findBySlug("c1") } returns course
-        every { request.getParameter("q") } returns "keyword"
-        val articleAttrs = AssetAttributes("a-id", now, "u-id", now, "u-id")
-        val article = Article(articleAttrs, Validity.Empty, null, "art-slug", "Article 1", null, "p", "", "", "", true, false, "md", course.common.id, "m1")
-        every { courseService.searchArticlesInCourse(course.common.id, "keyword", 50) } returns listOf(article)
+            val now = Instant.now()
+            val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
+            val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(Module("m1", "Mod", null, null, null)))
+            every { courseService.findBySlug("c1") } returns course
+            every { request.getParameter("q") } returns "keyword"
+            val articleAttrs = AssetAttributes("a-id", now, "u-id", now, "u-id")
+            val article = Article(
+                articleAttrs,
+                Validity.Empty,
+                null,
+                "art-slug",
+                "Article 1",
+                null,
+                "p",
+                "",
+                "",
+                "",
+                true,
+                false,
+                "md",
+                course.common.id,
+                "m1"
+            )
+            every { courseService.searchArticlesInCourse(course.common.id, "keyword", 50) } returns listOf(article)
 
-        val controller = CourseController(courseService, components)
-        val mv = controller.searchInCourse(request, "c1") as org.springframework.web.servlet.ModelAndView
-        mv.viewName shouldBe "member/courses/detail"
-        val articles = mv.model["articles"] as List<*>
-        articles.size shouldBe 1
-        val a = articles[0] as Article
-        a.courseId shouldBe course.common.id
-        verify { courseService.searchArticlesInCourse(course.common.id, "keyword", 50) }
-    }
+            // provide logged user and stub user courses so controller authorizes access
+            val userAttrs = AssetAttributes("u-id", now, "u-id", now, "u-id")
+            val user = User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
+            every { components.getLoggedUser(request) } returns user
+            every { courseService.findCoursesForUser(user.common.id) } returns listOf(course)
 
-    "module view lists only module-specific articles and requires authentication" {
-        val courseService = mockk<CourseService>()
-        val components = mockk<ControllerComponents>(relaxed = true)
-        val request = mockk<HttpServletRequest>(relaxed = true)
+            val controller = CourseController(courseService, components)
+            val mv = controller.searchInCourse(request, "c1") as org.springframework.web.servlet.ModelAndView
+            mv.viewName shouldBe "member/courses/detail"
+            val articles = mv.model["articles"] as List<*>
+            articles.size shouldBe 1
+            val a = articles[0] as Article
+            a.courseId shouldBe course.common.id
+            verify { courseService.searchArticlesInCourse(course.common.id, "keyword", 50) }
+        }
 
-        val now = Instant.now()
-        val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
-        val module = Module("m1", "Mod", null, null, null)
-        val otherModule = Module("m2", "Other", null, null, null)
-        val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(module, otherModule))
-        every { courseService.findBySlug("c1") } returns course
-        // articles include one for m1 and one for m2
-        val articleAttrs = AssetAttributes("a-id", now, "u-id", now, "u-id")
-        val a1 = Article(articleAttrs, Validity.Empty, null, "art-slug-1", "Article 1", null, "p", "", "", "", true, false, "md", course.common.id, "m1")
-        val a2 = Article(articleAttrs, Validity.Empty, null, "art-slug-2", "Article 2", null, "p", "", "", "", true, false, "md", course.common.id, "m2")
-        every { courseService.searchArticlesInCourse(course.common.id, "", 100) } returns listOf(a1, a2)
+        "module view lists only module-specific articles and requires authentication" {
+            val courseService = mockk<CourseService>()
+            val components = mockk<ControllerComponents>(relaxed = true)
+            val request = mockk<HttpServletRequest>(relaxed = true)
 
-        // provide logged user
-        val userAttrs = AssetAttributes("u-id", now, "u-id", now, "u-id")
-        val user = org.xbery.artbeams.users.domain.User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
-        every { components.getLoggedUser(request) } returns user
+            val now = Instant.now()
+            val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
+            val module = Module("m1", "Mod", null, null, null)
+            val otherModule = Module("m2", "Other", null, null, null)
+            val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(module, otherModule))
+            every { courseService.findBySlug("c1") } returns course
+            // articles include one for m1 and one for m2
+            val articleAttrs = AssetAttributes("a-id", now, "u-id", now, "u-id")
+            val a1 = Article(
+                articleAttrs,
+                Validity.Empty,
+                null,
+                "art-slug-1",
+                "Article 1",
+                null,
+                "p",
+                "",
+                "",
+                "",
+                true,
+                false,
+                "md",
+                course.common.id,
+                "m1"
+            )
+            val a2 = Article(
+                articleAttrs,
+                Validity.Empty,
+                null,
+                "art-slug-2",
+                "Article 2",
+                null,
+                "p",
+                "",
+                "",
+                "",
+                true,
+                false,
+                "md",
+                course.common.id,
+                "m2"
+            )
+            every { courseService.searchArticlesInCourse(course.common.id, "", 100) } returns listOf(a1, a2)
 
-        val controller = CourseController(courseService, components)
-        val mv = controller.moduleView(request, "c1", "m1") as org.springframework.web.servlet.ModelAndView
-        mv.viewName shouldBe "member/courses/module"
-        val articles = mv.model["articles"] as List<*>
-        articles.size shouldBe 1
-        val a = articles[0] as Article
-        a.moduleId shouldBe "m1"
-    }
+            // provide logged user
+            val userAttrs = AssetAttributes("u-id", now, "u-id", now, "u-id")
+            val user = org.xbery.artbeams.users.domain.User(
+                userAttrs,
+                "u1",
+                "pwd",
+                "First",
+                "Last",
+                "a@b",
+                emptyList()
+            )
+            every { components.getLoggedUser(request) } returns user
+            every { courseService.findCoursesForUser(user.common.id) } returns listOf(course)
 
-    "list courses redirects to login when not authenticated" {
-        val courseService = mockk<CourseService>()
-        val components = mockk<ControllerComponents>(relaxed = true)
-        val request = mockk<HttpServletRequest>(relaxed = true)
+            val controller = CourseController(courseService, components)
+            val mv = controller.moduleView(request, "c1", "m1") as org.springframework.web.servlet.ModelAndView
+            mv.viewName shouldBe "member/courses/module"
+            val articles = mv.model["articles"] as List<*>
+            articles.size shouldBe 1
+            val a = articles[0] as Article
+            a.moduleId shouldBe "m1"
+        }
 
-        every { components.getLoggedUser(request) } returns null
+        "list courses redirects to login when not authenticated" {
+            val courseService = mockk<CourseService>()
+            val components = mockk<ControllerComponents>(relaxed = true)
+            val request = mockk<HttpServletRequest>(relaxed = true)
 
-        val controller = CourseController(courseService, components)
-        val res = controller.listCourses(request)
-        res shouldBe "redirect:/login"
-    }
+            every { components.getLoggedUser(request) } returns null
 
-})
+            val controller = CourseController(courseService, components)
+            val res = controller.listCourses(request)
+            res shouldBe "redirect:/login"
+        }
+
+    })

--- a/src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerTest.kt
@@ -1,0 +1,108 @@
+package org.xbery.artbeams.courses.controller
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.http.HttpServletRequest
+import org.xbery.artbeams.common.controller.ControllerComponents
+import org.xbery.artbeams.courses.domain.Course
+import org.xbery.artbeams.courses.domain.Module
+import org.xbery.artbeams.courses.service.CourseService
+import org.xbery.artbeams.users.domain.User
+import org.xbery.artbeams.common.assets.domain.AssetAttributes
+import org.xbery.artbeams.articles.domain.Article
+import org.xbery.artbeams.common.assets.domain.Validity
+import java.time.Instant
+
+class CourseControllerTest : StringSpec({
+
+    "list courses view contains courses model" {
+        val courseService = mockk<CourseService>()
+        val components = mockk<ControllerComponents>(relaxed = true)
+        val request = mockk<HttpServletRequest>(relaxed = true)
+
+        val now = Instant.now()
+        val userAttrs = AssetAttributes("u-id", now, "u-id", now, "u-id")
+        val user = User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
+        every { components.getLoggedUser(request) } returns user
+
+        val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
+        val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(Module("m1", "Mod", null, null, null)))
+        every { courseService.findCoursesForUser(user.common.id) } returns listOf(course)
+
+        val controller = CourseController(courseService, components)
+        val mv = controller.listCourses(request) as org.springframework.web.servlet.ModelAndView
+        mv.viewName shouldBe "member/courses/list"
+        (mv.model["courses"] as List<*>).size shouldBe 1
+    }
+
+    "search in course invokes course service and returns articles" {
+        val courseService = mockk<CourseService>()
+        val components = mockk<ControllerComponents>(relaxed = true)
+        val request = mockk<HttpServletRequest>(relaxed = true)
+
+        val now = Instant.now()
+        val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
+        val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(Module("m1", "Mod", null, null, null)))
+        every { courseService.findBySlug("c1") } returns course
+        every { request.getParameter("q") } returns "keyword"
+        val articleAttrs = AssetAttributes("a-id", now, "u-id", now, "u-id")
+        val article = Article(articleAttrs, Validity.Empty, null, "art-slug", "Article 1", null, "p", "", "", "", true, false, "md", course.common.id, "m1")
+        every { courseService.searchArticlesInCourse(course.common.id, "keyword", 50) } returns listOf(article)
+
+        val controller = CourseController(courseService, components)
+        val mv = controller.searchInCourse(request, "c1") as org.springframework.web.servlet.ModelAndView
+        mv.viewName shouldBe "member/courses/detail"
+        val articles = mv.model["articles"] as List<*>
+        articles.size shouldBe 1
+        val a = articles[0] as Article
+        a.courseId shouldBe course.common.id
+        verify { courseService.searchArticlesInCourse(course.common.id, "keyword", 50) }
+    }
+
+    "module view lists only module-specific articles and requires authentication" {
+        val courseService = mockk<CourseService>()
+        val components = mockk<ControllerComponents>(relaxed = true)
+        val request = mockk<HttpServletRequest>(relaxed = true)
+
+        val now = Instant.now()
+        val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
+        val module = Module("m1", "Mod", null, null, null)
+        val otherModule = Module("m2", "Other", null, null, null)
+        val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(module, otherModule))
+        every { courseService.findBySlug("c1") } returns course
+        // articles include one for m1 and one for m2
+        val articleAttrs = AssetAttributes("a-id", now, "u-id", now, "u-id")
+        val a1 = Article(articleAttrs, Validity.Empty, null, "art-slug-1", "Article 1", null, "p", "", "", "", true, false, "md", course.common.id, "m1")
+        val a2 = Article(articleAttrs, Validity.Empty, null, "art-slug-2", "Article 2", null, "p", "", "", "", true, false, "md", course.common.id, "m2")
+        every { courseService.searchArticlesInCourse(course.common.id, "", 100) } returns listOf(a1, a2)
+
+        // provide logged user
+        val userAttrs = AssetAttributes("u-id", now, "u-id", now, "u-id")
+        val user = org.xbery.artbeams.users.domain.User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
+        every { components.getLoggedUser(request) } returns user
+
+        val controller = CourseController(courseService, components)
+        val mv = controller.moduleView(request, "c1", "m1") as org.springframework.web.servlet.ModelAndView
+        mv.viewName shouldBe "member/courses/module"
+        val articles = mv.model["articles"] as List<*>
+        articles.size shouldBe 1
+        val a = articles[0] as Article
+        a.moduleId shouldBe "m1"
+    }
+
+    "list courses redirects to login when not authenticated" {
+        val courseService = mockk<CourseService>()
+        val components = mockk<ControllerComponents>(relaxed = true)
+        val request = mockk<HttpServletRequest>(relaxed = true)
+
+        every { components.getLoggedUser(request) } returns null
+
+        val controller = CourseController(courseService, components)
+        val res = controller.listCourses(request)
+        res shouldBe "redirect:/login"
+    }
+
+})

--- a/src/test/kotlin/org/xbery/artbeams/members/controller/MemberSectionControllerTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/members/controller/MemberSectionControllerTest.kt
@@ -4,52 +4,53 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
-import jakarta.servlet.http.HttpServletRequest
-import org.xbery.artbeams.common.controller.ControllerComponents
-import org.xbery.artbeams.orders.service.OrderService
-import org.xbery.artbeams.userproducts.service.UserProductService
-import org.xbery.artbeams.users.domain.User
 import org.xbery.artbeams.common.assets.domain.AssetAttributes
+import org.xbery.artbeams.common.controller.ControllerComponents
 import org.xbery.artbeams.courses.domain.Course
 import org.xbery.artbeams.courses.domain.Module
 import org.xbery.artbeams.courses.service.CourseService
+import org.xbery.artbeams.orders.service.OrderService
+import org.xbery.artbeams.userproducts.service.UserProductService
+import org.xbery.artbeams.users.domain.User
 import java.time.Instant
+import jakarta.servlet.http.HttpServletRequest
 
-class MemberSectionControllerTest : StringSpec({
+class MemberSectionControllerTest :
+    StringSpec({
 
-    "member section model contains courses for logged user" {
-        val userProductService = mockk<UserProductService>()
-        val orderService = mockk<OrderService>()
-        val courseService = mockk<CourseService>()
+        "member section model contains courses for logged user" {
+            val userProductService = mockk<UserProductService>()
+            val orderService = mockk<OrderService>()
+            val courseService = mockk<CourseService>()
 
-        val components = mockk<ControllerComponents>(relaxed = true)
-        val request = mockk<HttpServletRequest>(relaxed = true)
+            val components = mockk<ControllerComponents>(relaxed = true)
+            val request = mockk<HttpServletRequest>(relaxed = true)
 
-        // create a logged user
-        val now = Instant.now()
-        val userAttrs = AssetAttributes("u-id", now, "u-id", now, "u-id")
-        val user = User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
-        every { components.getLoggedUser(request) } returns user
+            // create a logged user
+            val now = Instant.now()
+            val userAttrs = AssetAttributes("u-id", now, "u-id", now, "u-id")
+            val user = User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
+            every { components.getLoggedUser(request) } returns user
 
-        // stub user products
-        every { userProductService.findUserProducts(request) } returns emptyList()
+            // stub user products
+            every { userProductService.findUserProducts(request) } returns emptyList()
 
-        val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
-        val course = Course(
-            common = courseAttrs,
-            slug = "c1",
-            title = "Course 1",
-            subtitle = null,
-            listingImage = null,
-            image = null,
-            perex = "intro",
-            modules = listOf(Module("m1", "Module 1", null, null, null))
-        )
-        every { courseService.findCoursesForUser(user.common.id) } returns listOf(course)
+            val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
+            val course = Course(
+                common = courseAttrs,
+                slug = "c1",
+                title = "Course 1",
+                subtitle = null,
+                listingImage = null,
+                image = null,
+                perex = "intro",
+                modules = listOf(Module("m1", "Module 1", null, null, null))
+            )
+            every { courseService.findCoursesForUser(user.common.id) } returns listOf(course)
 
-        val controller = MemberSectionController(userProductService, orderService, courseService, components)
-        val mv = controller.memberSectionHome(request) as org.springframework.web.servlet.ModelAndView
-        mv.model["courses"] shouldNotBe null
-    }
+            val controller = MemberSectionController(userProductService, orderService, courseService, components)
+            val mv = controller.memberSectionHome(request) as org.springframework.web.servlet.ModelAndView
+            mv.model["courses"] shouldNotBe null
+        }
 
-})
+    })

--- a/src/test/kotlin/org/xbery/artbeams/members/controller/MemberSectionControllerTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/members/controller/MemberSectionControllerTest.kt
@@ -1,0 +1,55 @@
+package org.xbery.artbeams.members.controller
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
+import org.xbery.artbeams.common.controller.ControllerComponents
+import org.xbery.artbeams.orders.service.OrderService
+import org.xbery.artbeams.userproducts.service.UserProductService
+import org.xbery.artbeams.users.domain.User
+import org.xbery.artbeams.common.assets.domain.AssetAttributes
+import org.xbery.artbeams.courses.domain.Course
+import org.xbery.artbeams.courses.domain.Module
+import org.xbery.artbeams.courses.service.CourseService
+import java.time.Instant
+
+class MemberSectionControllerTest : StringSpec({
+
+    "member section model contains courses for logged user" {
+        val userProductService = mockk<UserProductService>()
+        val orderService = mockk<OrderService>()
+        val courseService = mockk<CourseService>()
+
+        val components = mockk<ControllerComponents>(relaxed = true)
+        val request = mockk<HttpServletRequest>(relaxed = true)
+
+        // create a logged user
+        val now = Instant.now()
+        val userAttrs = AssetAttributes("u-id", now, "u-id", now, "u-id")
+        val user = User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
+        every { components.getLoggedUser(request) } returns user
+
+        // stub user products
+        every { userProductService.findUserProducts(request) } returns emptyList()
+
+        val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
+        val course = Course(
+            common = courseAttrs,
+            slug = "c1",
+            title = "Course 1",
+            subtitle = null,
+            listingImage = null,
+            image = null,
+            perex = "intro",
+            modules = listOf(Module("m1", "Module 1", null, null, null))
+        )
+        every { courseService.findCoursesForUser(user.common.id) } returns listOf(course)
+
+        val controller = MemberSectionController(userProductService, orderService, courseService, components)
+        val mv = controller.memberSectionHome(request) as org.springframework.web.servlet.ModelAndView
+        mv.model["courses"] shouldNotBe null
+    }
+
+})


### PR DESCRIPTION
Fixes #61

## Evaluation

⚠️ Acceptance criteria not fully satisfied after 2 iteration(s):
- E2E smoke run failed: scripts/e2e/run_smoke_courses.sh exited early because 'psql' is not available in PATH (error: 'psql not found in PATH and PSQL_CMD not set'). The E2E script requires a PostgreSQL client, a running reachable database with credentials matching sprint-memory.md, and the seed SQL (scripts/seed_courses_e2e.sql) to be applied. Fix by providing psql in PATH in CI or setting PSQL_CMD to a working psql command (or make the script support Docker/Testcontainers).
- E2E smoke run prerequisites missing: Node.js/npm are required to run the browser script (scripts/e2e/smoke_courses_mcp.js). The script checks for node and npm and will fail if absent. Ensure Node.js and npm are installed in the environment and 'npm ci' in scripts/e2e completes successfully before running the MCP script.
- E2E run environment: the script starts the application via start.sh or './gradlew bootRun' and requires the app to be able to connect to the seeded database and bind to localhost:8080. CI must provide DB credentials (or allow using an embedded/test DB), and ensure start.sh works in the headless CI environment so the browser script can connect.

## Code review

⚠️ Actionable review findings remained after 2 iteration(s):
- [critical/security] Missing authorization check for course access: CourseController (src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt) loads a course by slug (findBySlug) and returns the detail/module/search pages for any authenticated user, but never verifies the logged-in user actually has access to that course (e.g. via courseService.findCoursesForUser or a dedicated authorization check). This allows any logged-in user to view courses they haven't purchased/been granted. Fix: enforce course membership — either have CourseService.findBySlug validate access when called from member endpoints, or (preferably) call courseService.findCoursesForUser(loggedUserId) and ensure the requested course is in that list before returning the page; return 404/403 otherwise.
- [normal/completeness] Course detail and module views don't populate 'courses' for the sidebar/menu: Templates member/courses/detail.ftl and member/courses/module.ftl render a sidebar/menu using the 'courses' model attribute (id="menu-kurz"), but CourseController.courseDetail, moduleView and searchInCourse do not add 'courses' to the model. As a result the menu will be empty on those pages. Fix: populate model['courses'] = courseService.findCoursesForUser(loggedUser.common.id) (or reuse an existing helper) so the menu shows available courses on detail/module/search pages.

---
Automation details:
- Branch: issue-61-implement-member-facing-course-pages-men-9aef9b
- Diff stat:

```
.../courses/controller/CourseController.kt         |  79 +++++++++++++++
 .../members/controller/MemberSectionController.kt  |   7 ++
 .../resources/templates/member/courses/detail.ftl  |  40 ++++++++
 .../resources/templates/member/courses/list.ftl    |  30 ++++++
 .../resources/templates/member/courses/module.ftl  |  28 ++++++
 .../courses/controller/CourseControllerTest.kt     | 108 +++++++++++++++++++++
 .../controller/MemberSectionControllerTest.kt      |  55 +++++++++++
 7 files changed, 347 insertions(+)
```