### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781931601444.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781931601444.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781931601444",
+  "planning": {
+    "input": 50404,
+    "cached_input": 541824,
+    "cache_write": 0,
+    "output": 4817,
+    "reasoning": 2048,
+    "cost": 0.039877,
+    "updated_at": "2026-06-20T05:02:08.509Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -88,9 +88,9 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-- (none)
+- Run idempotent E2E smoke for Courses (Chrome DevTools MCP): exercise member-facing Course menu, course detail, module list, article detail and per-course search using scripts/e2e/run_smoke_courses.sh; capture screenshots and browser logs to iterate on regressions. Rationale: End-to-end verification is still required by the DoD and can be executed once the in-flight admin/member UI work merges. Concrete artifacts: scripts/e2e/run_smoke_courses.sh, scripts/e2e/smoke_courses_mcp.js, scripts/seed_courses_e2e.sql, templates under src/main/resources/templates/member/courses.
 
 
 ## Later / ideas
 
-- Run idempotent E2E smoke for Courses (Chrome DevTools MCP): exercise member-facing Course menu, course detail, module list, article detail and per-course search using scripts/e2e/run_smoke_courses.sh; capture screenshots and browser logs to iterate on regressions. Rationale: End-to-end verification is still required by the DoD and can be executed once the in-flight admin/member UI work merges. Concrete artifacts: scripts/e2e/run_smoke_courses.sh, scripts/e2e/seed_courses.sql, templates under src/main/resources/templates/member/courses.
+- (none)


### PR DESCRIPTION
## Planning run
_Reconciled: Next up was empty; the Later item 'Run idempotent E2E smoke for Courses' is well-grounded and was promoted. Picked: the E2E smoke because it directly addresses the unmet DoD item 'End-to-end test the complete application' and uses existing scripts (scripts/e2e/run_smoke_courses.sh). Skipped: admin CRUD work is already tracked by open issues #59 and #67 so we avoid duplicate work. Risks: the app must be runnable locally (psql and Node.js required) and the test may fail if admin UI work isn't merged yet; attach logs/artifacts for debugging._
**Stuck/state snapshot:** 2 worker-mention open, 2 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Run idempotent E2E smoke for Courses (Chrome DevTools MCP)** (estimate: M)

   Run the idempotent Courses E2E smoke using the existing MCP/puppeteer script and seed data.
   
   Context: scripts/e2e/run_smoke_courses.sh, scripts/e2e/smoke_courses_mcp.js, scripts/seed_courses_e2e.sql, src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt, src/main/resources/templates/member/courses/*.ftl
   
   ## Acceptance Criteria
   
   1. Running the top-level shell script exits with status 0: ./scripts/e2e/run_smoke_courses.sh (the CI/dev machine should be able to run this command) and it produces exit code 0.
   2. The script writes artifacts to scripts/e2e/artifacts including a success screenshot scripts/e2e/artifacts/course-detail.png. The run logs and artifacts are attached to the job run for inspection.
   3. The script's idempotence SQL checks pass: after running the seed (scripts/seed_courses_e2e.sql) the psql checks in the script report exactly 1 user with login 'testmember' and at least 1 product with slug 'kurz-zdraveho-stravovani'.
   4. The script checks application logs for stack traces; confirm no Java stack traces or obvious exceptions are present in .e2e_app.log (the script already does this and fails on traces). Re-run if traces are detected and attach the tail of .e2e_app.log for debugging.
   5. Explicit Chrome DevTools MCP verification: node scripts/e2e/smoke_courses_mcp.js --baseUrl=http://localhost:8080 --artifacts=scripts/e2e/artifacts navigates to /login, logs in as testmember, navigates to /clenska-sekce, finds a course link and navigates to the course detail page, and saves scripts/e2e/artifacts/course-detail.png. The presence of either .module-list or .article-list on the course detail page is asserted by the script.
   
   @worker
   
   Scope: M
   
   
   ---
   _Grade: 5/5 | Covers: End-to-end test the complete application by running it locally, with idempotent seed script for filling all data needed to be present in database for full testing. Use Chrome DevTools MCP tools for evaluation of all the user journeys like the humans do through the typing, clicking, seeing (taking screenshots), observing application logs and errors, network traffic and console errors in the browser. | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._