### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1781938801734.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1781938801734.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1781938801734",
+  "planning": {
+    "input": 108830,
+    "cached_input": 327296,
+    "cache_write": 0,
+    "output": 4502,
+    "reasoning": 4736,
+    "cost": 0.053866,
+    "updated_at": "2026-06-20T07:03:21.461Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -88,7 +88,7 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-- (none)
+- Add unit tests for Courses admin controllers and member menu presence
 
 
 ## Later / ideas


### PR DESCRIPTION
## Planning run
_Reconciled: input Next up was empty and several failure-condition items (admin UI, member menu) are still outstanding in sprint-state.json, while open implementation issues (#59, #67) exist. Picked: add focused unit/controller tests that codify the expected admin CRUD endpoints and the member menu presence; these tests are complementary to open implementation work and reduce risk by specifying behaviour up-front. Skipped: creating a duplicate implementation issue for admin CRUD because #59 already exists open. Risks: tests must be written as pure unit tests (MockK) to avoid DB/template dependencies; worker should not assume templates exist when asserting view names._
**Stuck/state snapshot:** 3 worker-mention open, 2 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Add unit tests for Courses admin controllers and member menu presence** (estimate: M)

   Add unit and controller tests specifying the admin Courses CRUD behaviour to drive the implementation.
   
   Context: will add tests under src/test/kotlin/org/xbery/artbeams/courses/admin/ (CourseAdminControllerTest.kt, ModuleAdminControllerTest.kt) and update existing member test at src/test/kotlin/org/xbery/artbeams/members/controller/MemberSectionControllerTest.kt as needed. Tests reference controller classes to be implemented at src/main/kotlin/org/xbery/artbeams/courses/admin/CourseAdminController.kt and src/main/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminController.kt and service interfaces in src/main/kotlin/org/xbery/artbeams/courses/service/*. The repository already contains Course domain and CourseServiceImpl at src/main/kotlin/org/xbery/artbeams/courses/service/CourseServiceImpl.kt.
   
   ## Acceptance Criteria
   
   1. Add unit tests under src/test/kotlin/org/xbery/artbeams/courses/admin/CourseAdminControllerTest.kt that assert:
      - GET /admin/courses returns a ModelAndView with view name "admin/courses/list" and model contains attribute "courses" when CourseService.findAllForAdmin() (mocked) returns a list. The test uses MockK and the existing ControllerComponents test helpers.
   2. Add unit tests under src/test/kotlin/org/xbery/artbeams/courses/admin/CourseAdminControllerTest.kt that assert:
      - POST to create/update course binds CourseForm, calls CourseService.save(course) (mocked) and redirects to the course list. Use MockK to verify the save call.
   3. Add a small test src/test/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminControllerTest.kt that asserts module listing and module-create POST delegate to ModuleService (mocked) and return expected view names.
   4. Update or add a member-side unit test (src/test/kotlin/org/xbery/artbeams/members/controller/MemberSectionControllerTest.kt) that asserts memberSection view includes courses menu when CourseService.findCoursesForUser(userId) returns non-empty list (this establishes the end-to-end UI expectation for menu presence).
   5. Run ./gradlew test and ensure the new tests compile and pass locally (CI will verify). The new tests must be pure unit tests (use MockK) so they don't require DB or template files to exist.
   
   ## Dependencies
   
   - This test-suite is intended to codify expected behaviour for the admin CRUD implementation; it is complementary to existing open issue #59 (Implement Courses admin CRUD and templates) and will help specify acceptance criteria for that work.
   
   @worker
   
   Scope: M
   
   
   ---
   _Grade: 5/5 | Covers: Administration of Courses is implemented, allowing administrators to create and manage Courses (sets of articles) and assign them to products, create list of modules within this course - each module with image, title, short description and perex content (introduction text). | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._