### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782021601614.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782021601614.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782021601614",
+  "planning": {
+    "input": 47959,
+    "cached_input": 640256,
+    "cache_write": 0,
+    "output": 3420,
+    "reasoning": 3392,
+    "cost": 0.04162,
+    "updated_at": "2026-06-21T06:04:45.142Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,8 +83,8 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-- (none)
+- Implement module loading in CourseRepository so Course.modules is populated from course_modules via ModuleRepository (touches src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt). This is a prerequisite for admin templates and article editor which expect modules to be present.
 
 ## Later / ideas
 
-- (none)
+_(none yet)_

--- a/sprint-state.json
+++ b/sprint-state.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "status": "active",
+  "verdict": "in_progress",
+  "setBy": "system",
+  "updatedAt": "2026-06-21T06:00:44.397Z",
+  "evidence": [],
+  "unmet": [],
+  "notes": "",
+  "blockers": []
+}


### PR DESCRIPTION
## Planning run
_Reconciled: Next up was empty; there are open course work items (#59, #67) but they are in-flight. Picked: implement module-loading in CourseRepository because it's a small, prerequisite backend fix (removes TODO in src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt) that unblock admin templates and the article editor which read course.modules. Skipped: do not duplicate existing open issues #59/#67. Risks: touching repository constructor requires test updates (CourseRepositorySmokeTest) which were updated; no DB migration or jOOQ generation is required for this patch._
**Stuck/state snapshot:** 3 worker-mention open, 2 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Load Course modules in CourseRepository** (estimate: M)

   Load Course modules in CourseRepository so Course.modules is populated
   
   Context: src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt (class CourseRepository), src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt (class ModuleRepository), and admin/editor usage at src/main/kotlin/org/xbery/artbeams/articles/admin/ArticleAdminController.kt which calls courseRepository.findById(...).modules.
   
   ## Acceptance Criteria
   
   1. CourseRepository's constructor accepts a ModuleRepository and the TODO about populating Course.modules is removed. Concretely, src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt overrides findById(id: String): Course? and findAll(): List<Course> and returns Course objects whose modules list is populated from ModuleRepository.findByCourseId(courseId).
   2. Unit tests updated: src/test/kotlin/org/xbery/artbeams/courses/CourseRepositorySmokeTest.kt constructs CourseRepository with a ModuleRepository mock and still asserts repository assignability (test compiles and passes). @worker
   3. Project compiles and unit tests run: executing ./gradlew test (or the specific CourseRepositorySmokeTest) succeeds locally inside the worker container (CI will also run tests). The change must not introduce new compilation errors.
   4. Code changes are limited to CourseRepository and tests; no DB migration or jOOQ regeneration is required by this change (the implementation delegates to ModuleRepository which remains the stub until migrations exist).
   
   ## Dependencies
   
   - None (works with existing ModuleRepository stub). 
   
   Scope: M
   
   
   ---
   _Grade: 5/5 | Covers: Article has possibility to be assigned to a course within existing article administration/editor. | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._