### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782022378828.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782022378828.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782022378828",
+  "planning": {
+    "input": 40023,
+    "cached_input": 336512,
+    "cache_write": 0,
+    "output": 2384,
+    "reasoning": 3520,
+    "cost": 0.030227,
+    "updated_at": "2026-06-21T06:14:59.447Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,7 +83,7 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-- Implement module loading in CourseRepository so Course.modules is populated from course_modules via ModuleRepository (touches src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt). This is a prerequisite for admin templates and article editor which expect modules to be present.
+_(none yet)_
 
 ## Later / ideas
 


### PR DESCRIPTION
## Planning run
_Reconciled: The input Next up item requested module-loading in CourseRepository. The code already populates Course.modules via ModuleRepository, but there is no explicit unit test covering findById/findAll module population. Picked: add focused unit tests to verify CourseRepository calls ModuleRepository and includes returned modules, which directly satisfies the Next up verification and reduces risk for admin templates and article editor. Skipped: larger admin/controller tests because #59 and #73 cover those. Risks: writing unit tests that stub super.findById/findAll requires careful mocking (use MockK spies); acceptance criteria allow minimal production fixes if necessary._
**Stuck/state snapshot:** 3 worker-mention open, 2 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Add unit tests: CourseRepository populates modules from ModuleRepository** (estimate: M)

   Add unit tests to verify CourseRepository populates Course.modules from ModuleRepository
   
   Context: touches src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt and the ModuleRepository at src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt; new tests will live under src/test/kotlin/org/xbery/artbeams/courses/CourseRepositoryModulesTest.kt
   
   ## Acceptance Criteria
   
   1. A unit test file `src/test/kotlin/org/xbery/artbeams/courses/CourseRepositoryModulesTest.kt` exists and contains at least two tests: one asserting that `CourseRepository.findById(id)` returns a Course whose `modules` list equals the value returned by `ModuleRepository.findByCourseId(id)`, and one asserting the same for `CourseRepository.findAll()` (each returned Course has its `modules` populated by `ModuleRepository`). The tests must use MockK or equivalent test doubles and be deterministic.
   2. Running the specific tests succeeds: `./gradlew test --tests "org.xbery.artbeams.courses.CourseRepositoryModulesTest"` exits with status 0 (tests pass).
   3. The new tests reference the concrete implementation under `src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt` in their code comments or assertions so reviewers can see the linkage.
   4. No production code changes outside tests are required to make the tests pass; if minor production fixes are necessary, they must be minimal and limited to `CourseRepository.kt` and `ModuleRepository.kt` and be covered by the tests.
   
   ## Dependencies
   
   - None
   
   @worker
   
   Scope: M
   
   
   ---
   _Grade: 5/5 | Covers: Administration of Courses is implemented, allowing administrators to create and manage Courses (sets of articles) and assign them to products, create list of modules within this course - each module with image, title, short description and perex content (introduction text). | Priority: med_
_Issues created from this run will be listed as a comment on this PR once dispatched._