### PR TITLE
Add tests to prevent unauthorized access to Course (private) articles

### DIFF
--- a/.autoworker/cost/issue-94.json
+++ b/.autoworker/cost/issue-94.json
@@ -1,0 +1,13 @@
+{
+  "issue": 94,
+  "implementation": {
+    "input": 120871,
+    "cached_input": 1656192,
+    "cache_write": 0,
+    "output": 9573,
+    "reasoning": 7232,
+    "cost": 0.105233,
+    "updated_at": "2026-06-21T16:29:07.269Z"
+  },
+  "review": null
+}

--- a/.autoworker/cost/issue-94.json
+++ b/.autoworker/cost/issue-94.json
@@ -9,5 +9,13 @@
     "cost": 0.105233,
     "updated_at": "2026-06-21T16:29:07.269Z"
   },
-  "review": null
+  "review": {
+    "input": 29451,
+    "cached_input": 305152,
+    "cache_write": 0,
+    "output": 1632,
+    "reasoning": 512,
+    "cost": 0.01928,
+    "updated_at": "2026-06-21T18:07:10.529Z"
+  }
 }

--- a/src/test/kotlin/org/xbery/artbeams/articles/repository/ArticleRepositoryAccessTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/articles/repository/ArticleRepositoryAccessTest.kt
@@ -2,34 +2,34 @@ package org.xbery.artbeams.articles.repository
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import org.xbery.artbeams.jooq.schema.tables.references.ARTICLES
 import java.nio.file.Files
 import java.nio.file.Paths
 
-class ArticleRepositoryAccessTest : StringSpec({
+class ArticleRepositoryAccessTest :
+    StringSpec({
 
-    "findBySlug and findByQuery should filter out course-bound articles in source" {
-        // This test performs a small static inspection of the repository source
-        // to ensure the public search methods include ARTICLES.COURSE_ID.isNull
-        val path = Paths.get("src/main/kotlin/org/xbery/artbeams/articles/repository/ArticleRepository.kt")
-        val src = String(Files.readAllBytes(path))
+        "findBySlug and findByQuery should filter out course-bound articles in source" {
+            // This test performs a small static inspection of the repository source
+            // to ensure the public search methods include ARTICLES.COURSE_ID.isNull
+            val path = Paths.get("src/main/kotlin/org/xbery/artbeams/articles/repository/ArticleRepository.kt")
+            val src = String(Files.readAllBytes(path))
 
-        // findBySlug should filter out course-bound articles
-        src.contains("findBySlug") shouldBe true
-        src.contains("ARTICLES.COURSE_ID.isNull") shouldBe true
+            // findBySlug should filter out course-bound articles
+            src.contains("findBySlug") shouldBe true
+            src.contains("ARTICLES.COURSE_ID.isNull") shouldBe true
 
-        // findByQuery should also filter out course-bound articles
-        src.contains("fun findByQuery") shouldBe true
-        src.contains("ARTICLES.COURSE_ID.isNull") shouldBe true
-    }
+            // findByQuery should also filter out course-bound articles
+            src.contains("fun findByQuery") shouldBe true
+            src.contains("ARTICLES.COURSE_ID.isNull") shouldBe true
+        }
 
-    "findByQueryForCourse should use course id equality in where-clause" {
-        val path = Paths.get("src/main/kotlin/org/xbery/artbeams/articles/repository/ArticleRepository.kt")
-        val src = String(Files.readAllBytes(path))
+        "findByQueryForCourse should use course id equality in where-clause" {
+            val path = Paths.get("src/main/kotlin/org/xbery/artbeams/articles/repository/ArticleRepository.kt")
+            val src = String(Files.readAllBytes(path))
 
-        src.contains("fun findByQueryForCourse") shouldBe true
-        // ensure the per-course query uses ARTICLES.COURSE_ID.eq(courseId)
-        src.contains("ARTICLES.COURSE_ID.eq(courseId)") shouldBe true
-    }
+            src.contains("fun findByQueryForCourse") shouldBe true
+            // ensure the per-course query uses ARTICLES.COURSE_ID.eq(courseId)
+            src.contains("ARTICLES.COURSE_ID.eq(courseId)") shouldBe true
+        }
 
-})
+    })

--- a/src/test/kotlin/org/xbery/artbeams/articles/repository/ArticleRepositoryAccessTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/articles/repository/ArticleRepositoryAccessTest.kt
@@ -1,0 +1,35 @@
+package org.xbery.artbeams.articles.repository
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import org.xbery.artbeams.jooq.schema.tables.references.ARTICLES
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class ArticleRepositoryAccessTest : StringSpec({
+
+    "findBySlug and findByQuery should filter out course-bound articles in source" {
+        // This test performs a small static inspection of the repository source
+        // to ensure the public search methods include ARTICLES.COURSE_ID.isNull
+        val path = Paths.get("src/main/kotlin/org/xbery/artbeams/articles/repository/ArticleRepository.kt")
+        val src = String(Files.readAllBytes(path))
+
+        // findBySlug should filter out course-bound articles
+        src.contains("findBySlug") shouldBe true
+        src.contains("ARTICLES.COURSE_ID.isNull") shouldBe true
+
+        // findByQuery should also filter out course-bound articles
+        src.contains("fun findByQuery") shouldBe true
+        src.contains("ARTICLES.COURSE_ID.isNull") shouldBe true
+    }
+
+    "findByQueryForCourse should use course id equality in where-clause" {
+        val path = Paths.get("src/main/kotlin/org/xbery/artbeams/articles/repository/ArticleRepository.kt")
+        val src = String(Files.readAllBytes(path))
+
+        src.contains("fun findByQueryForCourse") shouldBe true
+        // ensure the per-course query uses ARTICLES.COURSE_ID.eq(courseId)
+        src.contains("ARTICLES.COURSE_ID.eq(courseId)") shouldBe true
+    }
+
+})

--- a/src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerAccessTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerAccessTest.kt
@@ -13,28 +13,29 @@ import org.xbery.artbeams.users.domain.User
 import java.time.Instant
 import jakarta.servlet.http.HttpServletRequest
 
-class CourseControllerAccessTest : StringSpec({
+class CourseControllerAccessTest :
+    StringSpec({
 
-    "courseDetail returns notFound when user does not have the course" {
-        val courseService = mockk<CourseService>()
-        val components = mockk<ControllerComponents>(relaxed = true)
-        val request = mockk<HttpServletRequest>(relaxed = true)
+        "courseDetail returns notFound when user does not have the course" {
+            val courseService = mockk<CourseService>()
+            val components = mockk<ControllerComponents>(relaxed = true)
+            val request = mockk<HttpServletRequest>(relaxed = true)
 
-        val now = Instant.now()
-        val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
-        val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(Module("m1", "Mod", null, null, null)))
-        every { courseService.findBySlug("c1") } returns course
+            val now = Instant.now()
+            val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
+            val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(Module("m1", "Mod", null, null, null)))
+            every { courseService.findBySlug("c1") } returns course
 
-        val userAttrs = AssetAttributes("u1", now, "u1", now, "u1")
-        val user = User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
-        every { components.getLoggedUser(request) } returns user
+            val userAttrs = AssetAttributes("u1", now, "u1", now, "u1")
+            val user = User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
+            every { components.getLoggedUser(request) } returns user
 
-        // user has no courses (didn't purchase the product)
-        every { courseService.findCoursesForUser(user.common.id) } returns emptyList()
+            // user has no courses (didn't purchase the product)
+            every { courseService.findCoursesForUser(user.common.id) } returns emptyList()
 
-        val controller = CourseController(courseService, components)
-        val res = controller.courseDetail(request, "c1")
-        (res as org.springframework.web.servlet.ModelAndView).viewName shouldBe "error404"
-    }
+            val controller = CourseController(courseService, components)
+            val res = controller.courseDetail(request, "c1")
+            (res as org.springframework.web.servlet.ModelAndView).viewName shouldBe "error404"
+        }
 
-})
+    })

--- a/src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerAccessTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerAccessTest.kt
@@ -1,0 +1,40 @@
+package org.xbery.artbeams.courses.controller
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.xbery.artbeams.common.assets.domain.AssetAttributes
+import org.xbery.artbeams.common.controller.ControllerComponents
+import org.xbery.artbeams.courses.domain.Course
+import org.xbery.artbeams.courses.domain.Module
+import org.xbery.artbeams.courses.service.CourseService
+import org.xbery.artbeams.users.domain.User
+import java.time.Instant
+import jakarta.servlet.http.HttpServletRequest
+
+class CourseControllerAccessTest : StringSpec({
+
+    "courseDetail returns notFound when user does not have the course" {
+        val courseService = mockk<CourseService>()
+        val components = mockk<ControllerComponents>(relaxed = true)
+        val request = mockk<HttpServletRequest>(relaxed = true)
+
+        val now = Instant.now()
+        val courseAttrs = AssetAttributes("c-id", now, "u-id", now, "u-id")
+        val course = Course(courseAttrs, "c1", "Course 1", null, null, null, "perex", listOf(Module("m1", "Mod", null, null, null)))
+        every { courseService.findBySlug("c1") } returns course
+
+        val userAttrs = AssetAttributes("u1", now, "u1", now, "u1")
+        val user = User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
+        every { components.getLoggedUser(request) } returns user
+
+        // user has no courses (didn't purchase the product)
+        every { courseService.findCoursesForUser(user.common.id) } returns emptyList()
+
+        val controller = CourseController(courseService, components)
+        val res = controller.courseDetail(request, "c1")
+        (res as org.springframework.web.servlet.ModelAndView).viewName shouldBe "error404"
+    }
+
+})

--- a/src/test/kotlin/org/xbery/artbeams/web/FreeProductControllerAuthTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/web/FreeProductControllerAuthTest.kt
@@ -5,84 +5,102 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import jakarta.servlet.http.HttpServletRequest
 import org.xbery.artbeams.articles.domain.Article
 import org.xbery.artbeams.articles.service.ArticleService
-import org.xbery.artbeams.common.controller.ControllerComponents
 import org.xbery.artbeams.common.assets.domain.AssetAttributes
 import org.xbery.artbeams.common.assets.domain.Validity
-import org.xbery.artbeams.products.domain.Product
+import org.xbery.artbeams.common.controller.ControllerComponents
 import org.xbery.artbeams.prices.domain.Price
+import org.xbery.artbeams.products.domain.Product
 import java.time.Instant
+import jakarta.servlet.http.HttpServletRequest
 
-class FreeProductControllerAuthTest : StringSpec({
+class FreeProductControllerAuthTest :
+    StringSpec({
 
-    "renderProductArticle returns notFound when article service returns null" {
-        val articleService = mockk<ArticleService>()
-        val productService = mockk<org.xbery.artbeams.products.service.ProductService>()
-        val components = mockk<ControllerComponents>(relaxed = true)
-        val request = mockk<HttpServletRequest>(relaxed = true)
+        "renderProductArticle returns notFound when article service returns null" {
+            val articleService = mockk<ArticleService>()
+            val productService = mockk<org.xbery.artbeams.products.service.ProductService>()
+            val components = mockk<ControllerComponents>(relaxed = true)
+            val request = mockk<HttpServletRequest>(relaxed = true)
 
-        val product = Product(AssetAttributes.EMPTY, "p1", "title", null, null, null, null, null, null, Price.ZERO, null, null)
-        every { productService.findBySlug("p1") } returns product
-        every { articleService.findBySlugPublic("p1") } returns null
+            val product = Product(AssetAttributes.EMPTY, "p1", "title", null, null, null, null, null, null, Price.ZERO, null, null)
+            every { productService.findBySlug("p1") } returns product
+            every { articleService.findBySlugPublic("p1") } returns null
 
-        val controller = FreeProductController(
-            components,
-            articleService,
-            productService,
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true)
-        )
+            val controller = FreeProductController(
+                components,
+                articleService,
+                productService,
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true)
+            )
 
-        val res = controller.productDetail(request, "p1")
-        // BaseController.notFound returns ModelAndView with viewName "error404"
-        (res as org.springframework.web.servlet.ModelAndView).viewName shouldBe "error404"
-        verify { articleService.findBySlugPublic("p1") }
-    }
+            val res = controller.productDetail(request, "p1")
+            // BaseController.notFound returns ModelAndView with viewName "error404"
+            (res as org.springframework.web.servlet.ModelAndView).viewName shouldBe "error404"
+            verify { articleService.findBySlugPublic("p1") }
+        }
 
-    "renderProductArticle returns ModelAndView when article exists" {
-        val articleService = mockk<ArticleService>()
-        val productService = mockk<org.xbery.artbeams.products.service.ProductService>()
-        val components = mockk<ControllerComponents>(relaxed = true)
-        val request = mockk<HttpServletRequest>(relaxed = true)
+        "renderProductArticle returns ModelAndView when article exists" {
+            val articleService = mockk<ArticleService>()
+            val productService = mockk<org.xbery.artbeams.products.service.ProductService>()
+            val components = mockk<ControllerComponents>(relaxed = true)
+            val request = mockk<HttpServletRequest>(relaxed = true)
 
-        val now = Instant.now()
-        val product = Product(AssetAttributes.EMPTY, "p1", "title", null, null, null, null, null, null, Price.ZERO, null, null)
-        every { productService.findBySlug("p1") } returns product
+            val now = Instant.now()
+            val product = Product(AssetAttributes.EMPTY, "p1", "title", null, null, null, null, null, null, Price.ZERO, null, null)
+            every { productService.findBySlug("p1") } returns product
 
-        val article = Article(AssetAttributes("a", now, "u", now, "u"), Validity.Empty, null, "p1", "t", null, "p", "", "", "", true, false, "md", null, null)
-        every { articleService.findBySlugPublic("p1") } returns article
+            val article =
+                Article(
+                    AssetAttributes("a", now, "u", now, "u"),
+                    Validity.Empty,
+                    null,
+                    "p1",
+                    "t",
+                    null,
+                    "p",
+                    "",
+                    "",
+                    "",
+                    true,
+                    false,
+                    "md",
+                    null,
+                    null
+                )
+            every { articleService.findBySlugPublic("p1") } returns article
 
-        val controller = FreeProductController(
-            components,
-            articleService,
-            productService,
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true),
-            mockk(relaxed = true)
-        )
+            val controller = FreeProductController(
+                components,
+                articleService,
+                productService,
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true),
+                mockk(relaxed = true)
+            )
 
-        val res = controller.productDetail(request, "p1")
-        (res as org.springframework.web.servlet.ModelAndView).viewName shouldBe "productArticle"
-        verify { articleService.findBySlugPublic("p1") }
-    }
+            val res = controller.productDetail(request, "p1")
+            (res as org.springframework.web.servlet.ModelAndView).viewName shouldBe "productArticle"
+            verify { articleService.findBySlugPublic("p1") }
+        }
 
-})
+    })

--- a/src/test/kotlin/org/xbery/artbeams/web/FreeProductControllerAuthTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/web/FreeProductControllerAuthTest.kt
@@ -1,0 +1,88 @@
+package org.xbery.artbeams.web
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.http.HttpServletRequest
+import org.xbery.artbeams.articles.domain.Article
+import org.xbery.artbeams.articles.service.ArticleService
+import org.xbery.artbeams.common.controller.ControllerComponents
+import org.xbery.artbeams.common.assets.domain.AssetAttributes
+import org.xbery.artbeams.common.assets.domain.Validity
+import org.xbery.artbeams.products.domain.Product
+import org.xbery.artbeams.prices.domain.Price
+import java.time.Instant
+
+class FreeProductControllerAuthTest : StringSpec({
+
+    "renderProductArticle returns notFound when article service returns null" {
+        val articleService = mockk<ArticleService>()
+        val productService = mockk<org.xbery.artbeams.products.service.ProductService>()
+        val components = mockk<ControllerComponents>(relaxed = true)
+        val request = mockk<HttpServletRequest>(relaxed = true)
+
+        val product = Product(AssetAttributes.EMPTY, "p1", "title", null, null, null, null, null, null, Price.ZERO, null, null)
+        every { productService.findBySlug("p1") } returns product
+        every { articleService.findBySlugPublic("p1") } returns null
+
+        val controller = FreeProductController(
+            components,
+            articleService,
+            productService,
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true)
+        )
+
+        val res = controller.productDetail(request, "p1")
+        // BaseController.notFound returns ModelAndView with viewName "error404"
+        (res as org.springframework.web.servlet.ModelAndView).viewName shouldBe "error404"
+        verify { articleService.findBySlugPublic("p1") }
+    }
+
+    "renderProductArticle returns ModelAndView when article exists" {
+        val articleService = mockk<ArticleService>()
+        val productService = mockk<org.xbery.artbeams.products.service.ProductService>()
+        val components = mockk<ControllerComponents>(relaxed = true)
+        val request = mockk<HttpServletRequest>(relaxed = true)
+
+        val now = Instant.now()
+        val product = Product(AssetAttributes.EMPTY, "p1", "title", null, null, null, null, null, null, Price.ZERO, null, null)
+        every { productService.findBySlug("p1") } returns product
+
+        val article = Article(AssetAttributes("a", now, "u", now, "u"), Validity.Empty, null, "p1", "t", null, "p", "", "", "", true, false, "md", null, null)
+        every { articleService.findBySlugPublic("p1") } returns article
+
+        val controller = FreeProductController(
+            components,
+            articleService,
+            productService,
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+            mockk(relaxed = true)
+        )
+
+        val res = controller.productDetail(request, "p1")
+        (res as org.springframework.web.servlet.ModelAndView).viewName shouldBe "productArticle"
+        verify { articleService.findBySlugPublic("p1") }
+    }
+
+})


### PR DESCRIPTION
Fixes #94

## Evaluation (read-only grade)

✅ Acceptance-criteria grade 72% — meets the 70% bar (iteration 1 of 2).

## Code review

✅ No actionable review findings remained after iteration 1.

---
Automation details:
- Branch: issue-94-add-server-side-tests-that-prevent-unaut-2c67f8
- Diff stat:

```
.autoworker/cost/issue-94.json                     | 13 ++++
 .../repository/ArticleRepositoryAccessTest.kt      | 35 +++++++++
 .../controller/CourseControllerAccessTest.kt       | 40 ++++++++++
 .../artbeams/web/FreeProductControllerAuthTest.kt  | 88 ++++++++++++++++++++++
 4 files changed, 176 insertions(+)
```