### PR TITLE
Planning: 0 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782061201512.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782061201512.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782061201512",
+  "planning": {
+    "input": 39560,
+    "cached_input": 206848,
+    "cache_write": 0,
+    "output": 2454,
+    "reasoning": 2688,
+    "cost": 0.025345,
+    "updated_at": "2026-06-21T17:01:49.028Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,14 +83,14 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-Stabilize and add server-side tests that prevent unauthorized access to Course (private) articles
-
-Add focused unit and integration tests that assert course-bound articles are never returned by public article APIs and that member-facing controllers deny access when the user does not have the purchased product. These tests are focused, complementary to existing CourseService tests, and target access-control failure conditions listed in SPRINT.md.
+Add admin-side unit tests for CourseAdminController and templates — expand coverage for edit form, delete and product list rendering (see CourseAdminController.kt and templates under src/main/resources/templates/admin/courses)
 
 ## Later / ideas
 
-- Add admin-side controller/template unit tests for Courses CRUD (see templates under src/main/resources/templates/admin/courses and CourseAdminController.kt)
+_(none yet)_
 
 - Harden e2e MCP smoke script to avoid manual DB steps and make idempotent (scripts/e2e/*)
+  Justification: useful follow-up to make smoke runs reliable once more tests are stable; touches scripts/e2e/*. Keep as Later.
 
 - Add JVM integration test profile using embedded H2 for fast verification of course access rules
+  Justification: larger change (DB migration + generateJooq run) — keep in Later until unit tests and access-control tests are merged.

--- a/plan-feedback.json
+++ b/plan-feedback.json
@@ -1,0 +1,12 @@
+{
+  "rejections": [
+    {
+      "title": "Add admin-side unit tests for CourseAdminController and templates",
+      "reason": "graded_out",
+      "detail": "grade 5/5, keep=false",
+      "runId": "plan-beranradek-artbeams-1782061201512",
+      "at": "2026-06-21T17:01:49.029Z"
+    }
+  ],
+  "updatedAt": "2026-06-21T17:01:49.029Z"
+}


### PR DESCRIPTION
## Planning run
_Reconciled: removed the previously listed Next-up item because an open issue (#94) already covers server-side access-control tests. Picked: promoted a grounded Later idea: add more admin-side controller/template unit tests focused on CourseAdminController.editForm and delete. Skipped: not creating JVM embedded-H2 integration or e2e hardening now (kept in Later). Risks: none significant; tests touch only test sources and use existing mockk conventions._
**Stuck/state snapshot:** 2 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
_No issues proposed this run._
### Rejected / dropped proposals
- Add admin-side unit tests for CourseAdminController and templates — graded_out (grade 5/5, keep=false)
_Issues created from this run will be listed as a comment on this PR once dispatched._