### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782064801682.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782064801682.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782064801682",
+  "planning": {
+    "input": 42141,
+    "cached_input": 378368,
+    "cache_write": 0,
+    "output": 2365,
+    "reasoning": 2688,
+    "cost": 0.0301,
+    "updated_at": "2026-06-21T18:02:13.585Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,14 +83,12 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-Add admin-side unit tests for CourseAdminController and templates — expand coverage for edit form, delete and product list rendering (see CourseAdminController.kt and templates under src/main/resources/templates/admin/courses)
+_(none yet)_
 
 ## Later / ideas
 
-_(none yet)_
-
 - Harden e2e MCP smoke script to avoid manual DB steps and make idempotent (scripts/e2e/*)
-  Justification: useful follow-up to make smoke runs reliable once more tests are stable; touches scripts/e2e/*. Keep as Later.
+  Justification: useful follow-up to make smoke runs reliable once more tests are stable; touches scripts/e2e/*. Keep in Later.
 
 - Add JVM integration test profile using embedded H2 for fast verification of course access rules
   Justification: larger change (DB migration + generateJooq run) — keep in Later until unit tests and access-control tests are merged.


### PR DESCRIPTION
## Planning run
_Reconciled: Next-up item existed in SPRINT.md requesting expanded admin-side tests for CourseAdminController. Picked: we create a single focused issue that adds tests for editForm (new and existing id), renderEditForm product population, and delete() invalid/valid flows. Skipped: no other Next-up items were pending. Risks: tests must follow existing project test style (JUnit5 + MockK); reviewer should ensure new tests do not depend on external DB or generated JOOQ classes._
**Stuck/state snapshot:** 2 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Add admin-side unit tests for CourseAdminController (edit, delete, product list)** (estimate: M)

   Add admin-side unit tests for CourseAdminController (edit, delete, product list)
   
   Context: Tests will live under src/test/kotlin/org/xbery/artbeams/courses/admin and exercise CourseAdminController.kt (functions: list, editForm, save, delete, renderEditForm) and the templates under src/main/resources/templates/admin/courses (courseEdit.ftl, courseList.ftl). They will mock CourseRepository, CourseService and ProductRepository.
   
   ## Acceptance Criteria
   
   1. A test file at src/test/kotlin/org/xbery/artbeams/courses/admin/CourseAdminControllerTest.kt or a sibling test file contains a test that calls CourseAdminController.editForm with id = null (new course) and asserts the returned ModelAndView.viewName is "admin/courses/courseEdit" and the model contains an editForm whose data.id equals AssetAttributes.EMPTY_ID. (refs: CourseAdminController.kt:editForm, courseEdit.ftl)
   
   2. A test in the same test source verifies editForm when an existing id is supplied: mocking CourseRepository.requireById(...) to return a Course, the test asserts the returned ModelAndView.viewName == "admin/courses/courseEdit" and that editForm.data.title matches the mocked course.title. (refs: CourseAdminController.kt:editForm, CourseRepository.requireById)
   
   3. A test verifies renderEditForm populates the "products" model key: mock ProductRepository.findProducts(Pagination(0,100)) to return a list and assert the controller model contains the exact list under "products" and the view name is "admin/courses/courseEdit". (refs: CourseAdminController.kt:renderEditForm, ProductRepository.findProducts)
   
   4. A test covers delete() invalid input: calling delete(...) with no id or EMPTY_ID must produce the BaseController.badRequest response; the test must assert the result is a ModelAndView and that BaseController.statusCodeToHttpStatus(StatusCode.BAD_INPUT) maps to HttpStatus.BAD_REQUEST (i.e. status present). (refs: CourseAdminController.kt:delete, BaseController.badRequest)
   
   5. A test covers delete() valid id: mock CourseService and verify courseService.deleteCourse(id, ...) is called exactly once and the controller returns the redirect string "redirect:/admin/courses". (refs: CourseAdminController.kt:delete, CourseService.deleteCourse)
   
   @worker
   
   Scope: M
   
   
   ---
   _Grade: 4/5 | Covers: Administration of Courses is implemented, allowing administrators to create and manage Courses (sets of articles) and assign them to products, create list of modules within this course - each module with image, title, short description and perex content (introduction text). | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._