### PR TITLE
Planning: 0 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782118801926.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782118801926.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782118801926",
+  "planning": {
+    "input": 38825,
+    "cached_input": 350848,
+    "cache_write": 0,
+    "output": 2944,
+    "reasoning": 2304,
+    "cost": 0.028973,
+    "updated_at": "2026-06-22T09:02:07.528Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,12 +83,9 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-Add JVM integration test profile using H2 for fast verification of course access rules
+Add JVM integration test profile using embedded H2 and test DB initializer (see issue to create).
 
-Reason: The sprint's Later queue contains a well-scoped task to add a test profile that uses an embedded H2 DB so JVM integration
-tests (particularly course access rules and repository-level checks) can run quickly and deterministically without requiring
-PostgreSQL. Implement a Spring Boot test profile, add H2 test dependency and a small TestDatabaseInitializer that executes
-src/main/resources/sql/create_tables.sql against the H2 DataSource.
+Reason: Provide a fast, deterministic Spring test profile so JVM integration tests (course access rules, repository-level checks) can run without PostgreSQL. The implementation will add a test-only application-test.yml, an H2 test dependency in build.gradle, and a TestDatabaseInitializer that executes src/main/resources/sql/create_tables.sql against the H2 DataSource.
 
 ## Later / ideas
 

--- a/plan-feedback.json
+++ b/plan-feedback.json
@@ -1,6 +1,13 @@
 {
   "rejections": [
     {
+      "title": "Add JVM test profile with embedded H2 and TestDatabaseInitializer",
+      "reason": "graded_out",
+      "detail": "grade 5/5, keep=false",
+      "runId": "plan-beranradek-artbeams-1782118801926",
+      "at": "2026-06-22T09:02:07.529Z"
+    },
+    {
       "title": "Add JVM integration test profile (H2) and test DB initializer",
       "reason": "graded_out",
       "detail": "grade 5/5, keep=false",
@@ -36,5 +43,5 @@
       "at": "2026-06-21T17:01:49.029Z"
     }
   ],
-  "updatedAt": "2026-06-22T08:01:48.278Z"
+  "updatedAt": "2026-06-22T09:02:07.529Z"
 }


### PR DESCRIPTION
## Planning run
_Reconciled: The Next up item 'Add JVM integration test profile using H2' is selected for implementation now because fast JVM tests are necessary to iterate on course access rules without PostgreSQL. Picked: a single M-sized issue that adds an H2 test dependency, a test-only application-test.yml, a TestDatabaseInitializer that runs src/main/resources/sql/create_tables.sql, and a small example @ActiveProfiles("test") integration test. Skipped: no other Next-up items. Risks: ensure create_tables.sql is compatible enough with H2 (the file already contains a note about H2 simulation); the implementer should set ResourceDatabasePopulator to continueOnError where PostgreSQL-specific DDL may not apply._
**Stuck/state snapshot:** 1 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
_No issues proposed this run._
### Rejected / dropped proposals
- Add JVM test profile with embedded H2 and TestDatabaseInitializer — graded_out (grade 5/5, keep=false)
_Issues created from this run will be listed as a comment on this PR once dispatched._