### PR TITLE
Planning: 0 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782122401610.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782122401610.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782122401610",
+  "planning": {
+    "input": 52661,
+    "cached_input": 309632,
+    "cache_write": 0,
+    "output": 2452,
+    "reasoning": 2176,
+    "cost": 0.030162,
+    "updated_at": "2026-06-22T10:02:04.728Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,9 +83,7 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-Add JVM integration test profile using embedded H2 and test DB initializer (see issue to create).
-
-Reason: Provide a fast, deterministic Spring test profile so JVM integration tests (course access rules, repository-level checks) can run without PostgreSQL. The implementation will add a test-only application-test.yml, an H2 test dependency in build.gradle, and a TestDatabaseInitializer that executes src/main/resources/sql/create_tables.sql against the H2 DataSource.
+_(none yet)_
 
 ## Later / ideas
 

--- a/plan-feedback.json
+++ b/plan-feedback.json
@@ -1,6 +1,13 @@
 {
   "rejections": [
     {
+      "title": "Add JVM integration test profile with embedded H2 and TestDatabaseInitializer",
+      "reason": "graded_out",
+      "detail": "grade 5/5, keep=false",
+      "runId": "plan-beranradek-artbeams-1782122401610",
+      "at": "2026-06-22T10:02:04.729Z"
+    },
+    {
       "title": "Add JVM test profile with embedded H2 and TestDatabaseInitializer",
       "reason": "graded_out",
       "detail": "grade 5/5, keep=false",
@@ -43,5 +50,5 @@
       "at": "2026-06-21T17:01:49.029Z"
     }
   ],
-  "updatedAt": "2026-06-22T09:02:07.529Z"
+  "updatedAt": "2026-06-22T10:02:04.729Z"
 }


### PR DESCRIPTION
## Planning run
_Reconciled: The sprint Next up requested a test profile using embedded H2. Previously similar proposals were graded_out; to address that this plan keeps all changes under src/test and avoids touching production code. Picked: a single M-sized issue that adds an H2 test dependency, application-test.yml, and a TestDatabaseInitializer that executes src/main/resources/sql/create_tables.sql via ResourceDatabasePopulator. Skipped: other unrelated Later ideas (none present). Risks: ensure the SQL script is H2-compatible; the initializer is implemented to ignore existing-object errors so repeated runs are safe._
**Stuck/state snapshot:** 1 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
_No issues proposed this run._
### Rejected / dropped proposals
- Add JVM integration test profile with embedded H2 and TestDatabaseInitializer — graded_out (grade 5/5, keep=false)
_Issues created from this run will be listed as a comment on this PR once dispatched._