### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782126001557.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782126001557.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782126001557",
+  "planning": {
+    "input": 56860,
+    "cached_input": 893440,
+    "cache_write": 0,
+    "output": 3789,
+    "reasoning": 3648,
+    "cost": 0.051425,
+    "updated_at": "2026-06-22T11:03:26.993Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,7 +83,11 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-_(none yet)_
+Add product_course DB table, CourseRepository product methods, and update CourseServiceImpl to enforce product-based course visibility and persist assignments.
+
+Rationale: CourseService currently returns all courses (CourseServiceImpl.findCoursesForUser uses CourseRepository.findAll()). The sprint-memory and admin forms (EditedCourse.productIds) imply a product_course join is required so courses are visible only to users who purchased assigned products. This work implements the DB table and repository/service plumbing so member-facing course lists and access checks can rely on stored assignments.
+
+See issue: .autoworker/issue-body-0.md
 
 ## Later / ideas
 


### PR DESCRIPTION
## Planning run
_Reconciled: Next-up was empty and the sprint memory / codebase show CourseServiceImpl.findCoursesForUser returns all courses while admin forms (EditedCourse.productIds) imply a product_course join. Picked: implement product_course DB migration and repository + service plumbing so courses are assigned to products and only shown to users with purchased products. Skipped: UI-only tweaks and member-page templates (those depend on backend product assignments). Risks: requires DB migration and jOOQ regen for full runtime; this issue limits changes to schema migration + repository/service methods to keep scope implementable in the ephemeral worker._
**Stuck/state snapshot:** 1 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Add product_course table and enforce product-based course visibility** (estimate: L)

   Persist Course↔Product assignments and enforce product-based course visibility.
   
   Context: This change touches the DB schema and backend service/repository layer. Key files to modify/implement are:
   - src/main/resources/sql/create_tables.sql (add product_course table)
   - src/main/resources/sql/migrations/add_product_course.sql (idempotent migration)
   - src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt (add methods: findCoursesForProduct, saveProductCourseAssignments, findProductIdsForCourse)
   - src/main/kotlin/org/xbery/artbeams/courses/service/CourseServiceImpl.kt (implement findCoursesForUser to consult UserProductRepository and courseRepository.findCoursesForProduct; persist assignments in saveCourse by parsing EditedCourse.productIds)
   - src/main/kotlin/org/xbery/artbeams/courses/admin/EditedCourse.kt (productIds field already exists)
   - src/main/kotlin/org/xbery/artbeams/userproducts/repository/UserProductRepository.kt (used to obtain purchased product ids)
   
   ## Acceptance Criteria
   
   1. Database migration: a new idempotent SQL migration file exists at src/main/resources/sql/migrations/add_product_course.sql and src/main/resources/sql/create_tables.sql is updated to include a product_course table with schema: (product_id VARCHAR(40) NOT NULL, course_id VARCHAR(40) NOT NULL, PRIMARY KEY (product_id, course_id)) plus indexes on product_id and course_id. The migration file contains CREATE TABLE IF NOT EXISTS and CREATE INDEX IF NOT EXISTS statements (file content is readable in the repo).
   
   2. CourseRepository exposes the following concrete methods (public signatures) implemented without TODOs in src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt:
      - fun findCoursesForProduct(productId: String): List<Course>
      - fun saveProductCourseAssignments(courseId: String, productIds: List<String>)
      - fun findProductIdsForCourse(courseId: String): List<String>
      Their implementations must use the injected DSLContext (dsl) to execute the necessary queries/inserts/deletes (i.e. JOOQ usage rather than string concatenation).
   
   3. CourseServiceImpl.findCoursesForUser(userId: String) (src/main/kotlin/org/xbery/artbeams/courses/service/CourseServiceImpl.kt) no longer returns courseRepository.findAll(). Instead it reads the user's purchased product ids via org.xbery.artbeams.userproducts.repository.UserProductRepository (or UserProductService) and returns the union of courseRepository.findCoursesForProduct(productId) for those product ids. The method contains no TODOs and clearly references UserProductRepository/API.
   
   4. CourseServiceImpl.saveCourse(...) parses EditedCourse.productIds (comma-separated string) and calls courseRepository.saveProductCourseAssignments(courseId, parsedProductIds) so admin changes to product assignments persist. The saveCourse implementation must not swallow exceptions silently: failures to persist assignments must be handled (caught and returned as null or rethrown) — the repository call must be present in code and not commented out.
   
   5. Security/property: The repository and service code added or modified use concrete JOOQ table references or DSLContext methods (no raw string SQL concatenation with untrusted inputs). The new code does not introduce any hard-coded credentials or secrets.
   
   @worker
   
   Scope: L
   
   
   ---
   _Grade: 5/5 | Covers: Administration of Courses is implemented, allowing administrators to create and manage Courses (sets of articles) and assign them to products, create list of modules within this course - each module with image, title, short description and perex content (introduction text). | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._