### PR TITLE
Planning: 0 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782127437589.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782127437589.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782127437589",
+  "planning": {
+    "input": 23042,
+    "cached_input": 165504,
+    "cache_write": 0,
+    "output": 1709,
+    "reasoning": 1280,
+    "cost": 0.015876,
+    "updated_at": "2026-06-22T11:25:04.205Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,11 +83,7 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-Add product_course DB table, CourseRepository product methods, and update CourseServiceImpl to enforce product-based course visibility and persist assignments.
-
-Rationale: CourseService currently returns all courses (CourseServiceImpl.findCoursesForUser uses CourseRepository.findAll()). The sprint-memory and admin forms (EditedCourse.productIds) imply a product_course join is required so courses are visible only to users who purchased assigned products. This work implements the DB table and repository/service plumbing so member-facing course lists and access checks can rely on stored assignments.
-
-See issue: .autoworker/issue-body-0.md
+_(none yet)_
 
 ## Later / ideas
 


### PR DESCRIPTION
## Planning run
_Reconciled: the input Next-up item asking for product_course DB table and repository/service changes is already implemented in the repository. Evidence: src/main/resources/sql/migrations/add_product_course.sql and src/main/resources/sql/create_tables.sql add the product_course table; jOOQ generated classes under src/main/jooqGenerated/** include ProductCourse and related tables.

Verified: CourseRepository.kt implements findCoursesForProduct() and saveProductCourseAssignments() and Module population (src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt). CourseServiceImpl.kt enforces product-based visibility (findCoursesForUser) and persists assignments in saveCourse (src/main/kotlin/org/xbery/artbeams/courses/service/CourseServiceImpl.kt). The change was committed in d03c7c8 and closed by issue #108.

Picked: no new issue this run because the Next-up item is stale. Skipped: creating a duplicate DB/repository change. Risks: none identified; there are no open deployment blockers._
**Stuck/state snapshot:** 1 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
_No issues proposed this run._
_Issues created from this run will be listed as a comment on this PR once dispatched._