### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782136801594.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782136801594.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782136801594",
+  "planning": {
+    "input": 45569,
+    "cached_input": 502784,
+    "cache_write": 0,
+    "output": 3890,
+    "reasoning": 3840,
+    "cost": 0.039422,
+    "updated_at": "2026-06-22T14:03:10.499Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,7 +83,9 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-_(none yet)_
+Implement article-detail member alias mapping `/a/{slug}` in WebController
+
+Rationale: member templates (src/main/resources/templates/member/courses/detail.ftl and module.ftl) link articles as `/a/${a.slug}` but the public article controller only handles `/{slug}` and uses ArticleService.findBySlugPublic. Add an alias route and member-access logic so course-bound articles are reachable from member pages while still enforcing course-product access.
 
 ## Later / ideas
 


### PR DESCRIPTION
## Planning run
_Reconciled: sprint-state indicated member templates link to /a/{slug} but no controller handled that path and module persistence was partially stubbed; the higher-priority failure is missing member-facing article detail route. Picked: implement alias mapping and member access checks in WebController so member pages can link to articles. Skipped: ModuleRepository persistence fix (still needed) because this run is capped to 1 issue; it should follow in next run. Risks: changing WebController constructor to inject CourseService is a cross-cutting change — keep change minimal and add unit tests under src/test/kotlin to assert correct branch selection._
**Stuck/state snapshot:** 1 worker-mention open, 1 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Add member-facing article alias route and access checks for /a/{slug}** (estimate: M)

   Add member-facing article alias route and access checks for /a/{slug}
   
   Summary
   Add support for the member-facing article URL alias (/a/{slug}) so templates under member/courses can link to article details. The controller must use the non-public article lookup for the alias and enforce course access (only users who purchased the linked product can view course-bound articles). Public article behavior for /{slug} must be unchanged.
   
   Context
   This change touches the public article handling in: src/main/kotlin/org/xbery/artbeams/web/WebController.kt and the course/user access checks via: src/main/kotlin/org/xbery/artbeams/courses/service/CourseService.kt. Member templates that link the alias: src/main/resources/templates/member/courses/detail.ftl and src/main/resources/templates/member/courses/module.ftl. Article lookup APIs: src/main/kotlin/org/xbery/artbeams/articles/service/ArticleService.kt and implementation ArticleServiceImpl.kt.
   
   ## Acceptance Criteria
   1. WebController.kt exposes the article route for both public and member alias paths. The @GetMapping on the article handler must include the path "/a/{slug}" in addition to "/{slug}" (source: src/main/kotlin/org/xbery/artbeams/web/WebController.kt).
   2. The article handler in WebController.kt chooses lookup method based on request path: for requests whose URI starts with "/a/" it must call articleService.findBySlug(slug); for other requests it must call articleService.findBySlugPublic(slug). The conditional must be implemented by inspecting the HttpServletRequest (e.g. request.requestURI) inside the same method (file: WebController.kt). No separate controller class may be left as a stray TODO.
   3. When serving the alias path ("/a/{slug}") and the resolved Article has a non-null courseId, the controller must enforce membership access: obtain the logged user from controllerComponents.getLoggedUser(request) (or the model created by createModel) and call CourseService.findCoursesForUser(loggedUser.common.id). If the user's course list does not include the article.courseId the handler returns notFound(request). This logic must be present in WebController.kt and must reference CourseService.findCoursesForUser (file: src/main/kotlin/org/xbery/artbeams/courses/service/CourseService.kt).
   4. The alias route must not expose draft articles: when serving "/a/{slug}" the handler must check article.draft==false and return notFound(request) if draft==true (file: WebController.kt). The existing public behavior (/{slug} using findBySlugPublic) must remain unchanged.
   5. A unit test file exists at src/test/kotlin/org/xbery/artbeams/web/WebControllerArticleAliasTest.kt that stubs/mocks ArticleService and CourseService and contains at least two test methods asserting (by reading the test code) that: (a) requests to "/a/{slug}" use ArticleService.findBySlug and perform a course-access check via CourseService.findCoursesForUser, and (b) requests to "/{slug}" still call ArticleService.findBySlugPublic. The test file must have no TODOs and should reference the controller class under test (WebController).
   6. No TODOs or unfinished stubs remain in WebController.kt after the change; any new private helper methods must be in the same file and not left commented out (inspect src/main/kotlin/org/xbery/artbeams/web/WebController.kt).
   
   ## Dependencies
   - None (this change does not depend on other open issues in this sprint). 
   
   @worker
   Scope: M
   
   
   ---
   _Grade: 5/5 | Covers: Access to Course works when member user logs into member section, and can see menu with available Courses, visit their details up to nested article details. | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._