### PR TITLE
Add /a/{slug} alias for articles with course access checks

### DIFF
--- a/.autoworker/cost/issue-113.json
+++ b/.autoworker/cost/issue-113.json
@@ -9,5 +9,13 @@
     "cost": 0.097944,
     "updated_at": "2026-06-22T14:12:52.644Z"
   },
-  "review": null
+  "review": {
+    "input": 29752,
+    "cached_input": 91904,
+    "cache_write": 0,
+    "output": 1061,
+    "reasoning": 192,
+    "cost": 0.012242,
+    "updated_at": "2026-06-22T14:21:01.698Z"
+  }
 }

--- a/.autoworker/cost/issue-113.json
+++ b/.autoworker/cost/issue-113.json
@@ -1,0 +1,13 @@
+{
+  "issue": 113,
+  "implementation": {
+    "input": 124769,
+    "cached_input": 1650944,
+    "cache_write": 0,
+    "output": 8323,
+    "reasoning": 4416,
+    "cost": 0.097944,
+    "updated_at": "2026-06-22T14:12:52.644Z"
+  },
+  "review": null
+}

--- a/src/main/kotlin/org/xbery/artbeams/web/WebController.kt
+++ b/src/main/kotlin/org/xbery/artbeams/web/WebController.kt
@@ -282,109 +282,109 @@ class WebController(
         }
 
         val entityKey = EntityKey.fromClassAndId(Article::class.java, article.id)
-            val fUserAccessReport =
-                CompletableFuture.supplyAsync {
-                    controllerComponents.userAccessService.saveUserAccess(
-                        entityKey,
-                        request
-                    )
-                }
-            val fCountOfVisits =
-                CompletableFuture.supplyAsync {
-                    controllerComponents.userAccessService.findCountOfVisits(entityKey)
-                }
-            val fCommentsWithForm =
-                CompletableFuture.supplyAsync {
-                    if (article.showOnBlog) {
-                        val newComment =
-                            Comment.EMPTY.toEdited().copy(entityId = article.id)
-                        val comments = commentService.findApprovedByEntityId(article.id)
-                        val commentForm =
-                            commentFormDef.fill(
-                                FormData(newComment, ValidationResult.empty)
-                            )
-                        Pair<List<Comment>, FormMapping<EditedComment>?>(
-                            comments,
-                            commentForm
-                        )
-                    } else {
-                        Pair<List<Comment>, FormMapping<EditedComment>?>(listOf(), null)
-                    }
-                }
-            val fArticleCategories =
-                CompletableFuture.supplyAsync {
-                    // Cached method - categories per article are cached efficiently
-                    categoryService.findCategoriesByArticleId(article.id)
-                }
-            CompletableFuture
-                .allOf(
-                    fUserAccessReport,
-                    fCountOfVisits,
-                    fCommentsWithForm,
-                    fArticleCategories
-                ).join()
-            val commentsWithForm = fCommentsWithForm.get()
-            val articleCategories = fArticleCategories.get()
-
-            // Generate structured data for GEO/SEO
-            val siteUrl = getUrlBase(request)
-            val siteName =
-                controllerComponents.localisationRepository.getEntries()["website.title"]
-                    ?: "ArtBeams"
-            val logoUrl =
-                "$siteUrl${controllerComponents.localisationRepository.getEntries()["logo.img.src"] ?: "/media/favicon.ico"}"
-
-            val articleJsonLd =
-                StructuredDataGenerator.generateArticleJsonLd(
-                    article = article,
-                    author = null, // Author information from translations for now
-                    categories = articleCategories,
-                    siteUrl = siteUrl,
-                    siteName = siteName,
-                    logoUrl = logoUrl
-                )
-
-            // Generate breadcrumb structured data
-            val breadcrumbItems = mutableListOf<Pair<String, String>>()
-            breadcrumbItems.add(Pair(siteName, siteUrl))
-            if (articleCategories.isNotEmpty()) {
-                val primaryCategory = articleCategories.first()
-                breadcrumbItems.add(
-                    Pair(
-                        primaryCategory.title,
-                        "$siteUrl/kategorie/${primaryCategory.slug}"
-                    )
+        val fUserAccessReport =
+            CompletableFuture.supplyAsync {
+                controllerComponents.userAccessService.saveUserAccess(
+                    entityKey,
+                    request
                 )
             }
-            breadcrumbItems.add(Pair(article.title, "$siteUrl/${article.slug}"))
-            val breadcrumbJsonLd =
-                StructuredDataGenerator.generateBreadcrumbJsonLd(breadcrumbItems)
-
-            val faqs = faqService.findByEntity(FaqEntityType.ARTICLE, article.id)
-            val faqJsonLd =
-                if (faqs.isNotEmpty()) {
-                    StructuredDataGenerator.generateFaqJsonLd(faqs.map { it.question to it.answer })
+        val fCountOfVisits =
+            CompletableFuture.supplyAsync {
+                controllerComponents.userAccessService.findCountOfVisits(entityKey)
+            }
+        val fCommentsWithForm =
+            CompletableFuture.supplyAsync {
+                if (article.showOnBlog) {
+                    val newComment =
+                        Comment.EMPTY.toEdited().copy(entityId = article.id)
+                    val comments = commentService.findApprovedByEntityId(article.id)
+                    val commentForm =
+                        commentFormDef.fill(
+                            FormData(newComment, ValidationResult.empty)
+                        )
+                    Pair<List<Comment>, FormMapping<EditedComment>?>(
+                        comments,
+                        commentForm
+                    )
                 } else {
-                    null
+                    Pair<List<Comment>, FormMapping<EditedComment>?>(listOf(), null)
                 }
+            }
+        val fArticleCategories =
+            CompletableFuture.supplyAsync {
+                // Cached method - categories per article are cached efficiently
+                categoryService.findCategoriesByArticleId(article.id)
+            }
+        CompletableFuture
+            .allOf(
+                fUserAccessReport,
+                fCountOfVisits,
+                fCommentsWithForm,
+                fArticleCategories
+            ).join()
+        val commentsWithForm = fCommentsWithForm.get()
+        val articleCategories = fArticleCategories.get()
 
-            val model =
-                createBlogModel(
-                    request,
-                    FormData(SubscriptionFormData.Empty, ValidationResult.empty),
-                    "article" to article,
-                    "articleCategories" to articleCategories,
-                    "comments" to commentsWithForm.first,
-                    CommentController.TPL_PARAM_COMMENT_FORM to commentsWithForm.second,
-                    "userAccessReport" to fUserAccessReport.get(),
-                    "countOfVisits" to fCountOfVisits.get(),
-                    "articleJsonLd" to articleJsonLd,
-                    "breadcrumbJsonLd" to breadcrumbJsonLd,
-                    "faqs" to faqs,
-                    "faqJsonLd" to faqJsonLd
+        // Generate structured data for GEO/SEO
+        val siteUrl = getUrlBase(request)
+        val siteName =
+            controllerComponents.localisationRepository.getEntries()["website.title"]
+                ?: "ArtBeams"
+        val logoUrl =
+            "$siteUrl${controllerComponents.localisationRepository.getEntries()["logo.img.src"] ?: "/media/favicon.ico"}"
+
+        val articleJsonLd =
+            StructuredDataGenerator.generateArticleJsonLd(
+                article = article,
+                author = null, // Author information from translations for now
+                categories = articleCategories,
+                siteUrl = siteUrl,
+                siteName = siteName,
+                logoUrl = logoUrl
+            )
+
+        // Generate breadcrumb structured data
+        val breadcrumbItems = mutableListOf<Pair<String, String>>()
+        breadcrumbItems.add(Pair(siteName, siteUrl))
+        if (articleCategories.isNotEmpty()) {
+            val primaryCategory = articleCategories.first()
+            breadcrumbItems.add(
+                Pair(
+                    primaryCategory.title,
+                    "$siteUrl/kategorie/${primaryCategory.slug}"
                 )
-            return ModelAndView("article", model)
+            )
         }
+        breadcrumbItems.add(Pair(article.title, "$siteUrl/${article.slug}"))
+        val breadcrumbJsonLd =
+            StructuredDataGenerator.generateBreadcrumbJsonLd(breadcrumbItems)
+
+        val faqs = faqService.findByEntity(FaqEntityType.ARTICLE, article.id)
+        val faqJsonLd =
+            if (faqs.isNotEmpty()) {
+                StructuredDataGenerator.generateFaqJsonLd(faqs.map { it.question to it.answer })
+            } else {
+                null
+            }
+
+        val model =
+            createBlogModel(
+                request,
+                FormData(SubscriptionFormData.Empty, ValidationResult.empty),
+                "article" to article,
+                "articleCategories" to articleCategories,
+                "comments" to commentsWithForm.first,
+                CommentController.TPL_PARAM_COMMENT_FORM to commentsWithForm.second,
+                "userAccessReport" to fUserAccessReport.get(),
+                "countOfVisits" to fCountOfVisits.get(),
+                "articleJsonLd" to articleJsonLd,
+                "breadcrumbJsonLd" to breadcrumbJsonLd,
+                "faqs" to faqs,
+                "faqJsonLd" to faqJsonLd
+            )
+        return ModelAndView("article", model)
+    }
 
     private fun buildRssXml(siteUrl: String, siteName: String, siteDescription: String, articles: List<Article>): String {
         val rfc1123 = DateTimeFormatter.RFC_1123_DATE_TIME

--- a/src/main/kotlin/org/xbery/artbeams/web/WebController.kt
+++ b/src/main/kotlin/org/xbery/artbeams/web/WebController.kt
@@ -53,6 +53,7 @@ class WebController(
     private val articleCategoryRepository: ArticleCategoryRepository,
     val productService: ProductService,
     val commentService: CommentService,
+    private val courseService: org.xbery.artbeams.courses.service.CourseService,
     val controllerComponents: ControllerComponents,
     val resourceLoader: ResourceLoader,
     private val searchService: SearchService,
@@ -251,11 +252,36 @@ class WebController(
     }
 
     /** GET article detail. */
-    @GetMapping("/{slug}")
-    fun article(request: HttpServletRequest, @PathVariable slug: String?): Any = if (slug != null) {
-        val article = articleService.findBySlugPublic(slug)
-        if (article != null) {
-            val entityKey = EntityKey.fromClassAndId(Article::class.java, article.id)
+    @GetMapping(value = ["/{slug}", "/a/{slug}"])
+    fun article(request: HttpServletRequest, @PathVariable slug: String?): Any {
+        if (slug == null) {
+            return notFound(request)
+        }
+        val isAlias = request.requestURI.startsWith("/a/")
+        val article = if (isAlias) articleService.findBySlug(slug) else articleService.findBySlugPublic(slug)
+        if (article == null) {
+            return notFound(request)
+        }
+
+        // If this is alias path, enforce that drafts are not exposed and course access is checked
+        if (isAlias) {
+            if (article.draft) {
+                return notFound(request)
+            }
+            val loggedUser = controllerComponents.getLoggedUser(request)
+            if (article.courseId != null) {
+                // If user not logged or does not have access to the course, return 404
+                if (loggedUser == null) {
+                    return notFound(request)
+                }
+                val courses = courseService.findCoursesForUser(loggedUser.common.id)
+                if (courses.none { it.id == article.courseId }) {
+                    return notFound(request)
+                }
+            }
+        }
+
+        val entityKey = EntityKey.fromClassAndId(Article::class.java, article.id)
             val fUserAccessReport =
                 CompletableFuture.supplyAsync {
                     controllerComponents.userAccessService.saveUserAccess(
@@ -357,13 +383,8 @@ class WebController(
                     "faqs" to faqs,
                     "faqJsonLd" to faqJsonLd
                 )
-            ModelAndView("article", model)
-        } else {
-            notFound(request)
+            return ModelAndView("article", model)
         }
-    } else {
-        notFound(request)
-    }
 
     private fun buildRssXml(siteUrl: String, siteName: String, siteDescription: String, articles: List<Article>): String {
         val rfc1123 = DateTimeFormatter.RFC_1123_DATE_TIME

--- a/src/test/kotlin/org/xbery/artbeams/web/WebControllerArticleAliasTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/web/WebControllerArticleAliasTest.kt
@@ -1,0 +1,81 @@
+package org.xbery.artbeams.web
+
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.kotest.matchers.shouldBe
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.web.servlet.ModelAndView
+import org.xbery.artbeams.articles.domain.Article
+import org.xbery.artbeams.common.controller.ControllerComponents
+import org.xbery.artbeams.articles.service.ArticleService
+import org.xbery.artbeams.categories.service.CategoryService
+import org.xbery.artbeams.articles.repository.ArticleCategoryRepository
+import org.xbery.artbeams.products.service.ProductService
+import org.xbery.artbeams.comments.service.CommentService
+import org.xbery.artbeams.courses.service.CourseService
+import org.xbery.artbeams.common.assets.domain.AssetAttributes
+import java.time.Instant
+
+class WebControllerArticleAliasTest : StringSpec({
+
+    "alias path uses findBySlug and checks course access" {
+        val articleService = mockk<ArticleService>(relaxed = true)
+        val courseService = mockk<CourseService>(relaxed = true)
+        val categoryService = mockk<CategoryService>(relaxed = true)
+        val articleCategoryRepository = mockk<ArticleCategoryRepository>(relaxed = true)
+        val productService = mockk<ProductService>(relaxed = true)
+        val commentService = mockk<CommentService>(relaxed = true)
+        val components = mockk<ControllerComponents>(relaxed = true)
+        val request = mockk<HttpServletRequest>(relaxed = true)
+
+        // prepare article with courseId
+        val article = Article.Empty.copy(courseId = "c-1", slug = "a-slug", draft = false)
+        every { request.requestURI } returns "/a/a-slug"
+        every { articleService.findBySlug("a-slug") } returns article
+
+        // prepare logged user
+        val now = Instant.now()
+        val userAttrs = AssetAttributes("u-1", now, "u-1", now, "u-1")
+        val user = org.xbery.artbeams.users.domain.User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
+        every { components.getLoggedUser(request) } returns user
+
+        // courseService returns no courses (user has no access)
+        every { courseService.findCoursesForUser(user.common.id) } returns emptyList()
+
+        val controller = WebController(articleService, categoryService, articleCategoryRepository, productService, commentService, courseService, components, mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
+
+        val result = controller.article(request, "a-slug")
+        // should return 404 view
+        val mv = result as ModelAndView
+        mv.viewName shouldBe "error404"
+
+        verify { articleService.findBySlug("a-slug") }
+        verify { courseService.findCoursesForUser(user.common.id) }
+    }
+
+    "public path uses findBySlugPublic and does not check courses" {
+        val articleService = mockk<ArticleService>(relaxed = true)
+        val courseService = mockk<CourseService>(relaxed = true)
+        val categoryService = mockk<CategoryService>(relaxed = true)
+        val articleCategoryRepository = mockk<ArticleCategoryRepository>(relaxed = true)
+        val productService = mockk<ProductService>(relaxed = true)
+        val commentService = mockk<CommentService>(relaxed = true)
+        val components = mockk<ControllerComponents>(relaxed = true)
+        val request = mockk<HttpServletRequest>(relaxed = true)
+
+        val article = Article.Empty.copy(courseId = null, slug = "p-slug", draft = false)
+        every { request.requestURI } returns "/p-slug"
+        every { articleService.findBySlugPublic("p-slug") } returns article
+
+        val controller = WebController(articleService, categoryService, articleCategoryRepository, productService, commentService, courseService, components, mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
+        val result = controller.article(request, "p-slug")
+
+        // should have invoked public lookup
+        verify { articleService.findBySlugPublic("p-slug") }
+        // course service must not be invoked for public path
+        verify(exactly = 0) { courseService.findCoursesForUser(any()) }
+    }
+
+})

--- a/src/test/kotlin/org/xbery/artbeams/web/WebControllerArticleAliasTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/web/WebControllerArticleAliasTest.kt
@@ -1,81 +1,107 @@
 package org.xbery.artbeams.web
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import io.kotest.matchers.shouldBe
-import jakarta.servlet.http.HttpServletRequest
 import org.springframework.web.servlet.ModelAndView
 import org.xbery.artbeams.articles.domain.Article
-import org.xbery.artbeams.common.controller.ControllerComponents
+import org.xbery.artbeams.articles.repository.ArticleCategoryRepository
 import org.xbery.artbeams.articles.service.ArticleService
 import org.xbery.artbeams.categories.service.CategoryService
-import org.xbery.artbeams.articles.repository.ArticleCategoryRepository
-import org.xbery.artbeams.products.service.ProductService
 import org.xbery.artbeams.comments.service.CommentService
-import org.xbery.artbeams.courses.service.CourseService
 import org.xbery.artbeams.common.assets.domain.AssetAttributes
+import org.xbery.artbeams.common.controller.ControllerComponents
+import org.xbery.artbeams.courses.service.CourseService
+import org.xbery.artbeams.products.service.ProductService
 import java.time.Instant
+import jakarta.servlet.http.HttpServletRequest
 
-class WebControllerArticleAliasTest : StringSpec({
+class WebControllerArticleAliasTest :
+    StringSpec({
 
-    "alias path uses findBySlug and checks course access" {
-        val articleService = mockk<ArticleService>(relaxed = true)
-        val courseService = mockk<CourseService>(relaxed = true)
-        val categoryService = mockk<CategoryService>(relaxed = true)
-        val articleCategoryRepository = mockk<ArticleCategoryRepository>(relaxed = true)
-        val productService = mockk<ProductService>(relaxed = true)
-        val commentService = mockk<CommentService>(relaxed = true)
-        val components = mockk<ControllerComponents>(relaxed = true)
-        val request = mockk<HttpServletRequest>(relaxed = true)
+        "alias path uses findBySlug and checks course access" {
+            val articleService = mockk<ArticleService>(relaxed = true)
+            val courseService = mockk<CourseService>(relaxed = true)
+            val categoryService = mockk<CategoryService>(relaxed = true)
+            val articleCategoryRepository = mockk<ArticleCategoryRepository>(relaxed = true)
+            val productService = mockk<ProductService>(relaxed = true)
+            val commentService = mockk<CommentService>(relaxed = true)
+            val components = mockk<ControllerComponents>(relaxed = true)
+            val request = mockk<HttpServletRequest>(relaxed = true)
 
-        // prepare article with courseId
-        val article = Article.Empty.copy(courseId = "c-1", slug = "a-slug", draft = false)
-        every { request.requestURI } returns "/a/a-slug"
-        every { articleService.findBySlug("a-slug") } returns article
+            // prepare article with courseId
+            val article = Article.Empty.copy(courseId = "c-1", slug = "a-slug", draft = false)
+            every { request.requestURI } returns "/a/a-slug"
+            every { articleService.findBySlug("a-slug") } returns article
 
-        // prepare logged user
-        val now = Instant.now()
-        val userAttrs = AssetAttributes("u-1", now, "u-1", now, "u-1")
-        val user = org.xbery.artbeams.users.domain.User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
-        every { components.getLoggedUser(request) } returns user
+            // prepare logged user
+            val now = Instant.now()
+            val userAttrs = AssetAttributes("u-1", now, "u-1", now, "u-1")
+            val user = org.xbery.artbeams.users.domain
+                .User(userAttrs, "u1", "pwd", "First", "Last", "a@b", emptyList())
+            every { components.getLoggedUser(request) } returns user
 
-        // courseService returns no courses (user has no access)
-        every { courseService.findCoursesForUser(user.common.id) } returns emptyList()
+            // courseService returns no courses (user has no access)
+            every { courseService.findCoursesForUser(user.common.id) } returns emptyList()
 
-        val controller = WebController(articleService, categoryService, articleCategoryRepository, productService, commentService, courseService, components, mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
+            val controller =
+                WebController(
+                    articleService,
+                    categoryService,
+                    articleCategoryRepository,
+                    productService,
+                    commentService,
+                    courseService,
+                    components,
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    mockk(relaxed = true)
+                )
 
-        val result = controller.article(request, "a-slug")
-        // should return 404 view
-        val mv = result as ModelAndView
-        mv.viewName shouldBe "error404"
+            val result = controller.article(request, "a-slug")
+            // should return 404 view
+            val mv = result as ModelAndView
+            mv.viewName shouldBe "error404"
 
-        verify { articleService.findBySlug("a-slug") }
-        verify { courseService.findCoursesForUser(user.common.id) }
-    }
+            verify { articleService.findBySlug("a-slug") }
+            verify { courseService.findCoursesForUser(user.common.id) }
+        }
 
-    "public path uses findBySlugPublic and does not check courses" {
-        val articleService = mockk<ArticleService>(relaxed = true)
-        val courseService = mockk<CourseService>(relaxed = true)
-        val categoryService = mockk<CategoryService>(relaxed = true)
-        val articleCategoryRepository = mockk<ArticleCategoryRepository>(relaxed = true)
-        val productService = mockk<ProductService>(relaxed = true)
-        val commentService = mockk<CommentService>(relaxed = true)
-        val components = mockk<ControllerComponents>(relaxed = true)
-        val request = mockk<HttpServletRequest>(relaxed = true)
+        "public path uses findBySlugPublic and does not check courses" {
+            val articleService = mockk<ArticleService>(relaxed = true)
+            val courseService = mockk<CourseService>(relaxed = true)
+            val categoryService = mockk<CategoryService>(relaxed = true)
+            val articleCategoryRepository = mockk<ArticleCategoryRepository>(relaxed = true)
+            val productService = mockk<ProductService>(relaxed = true)
+            val commentService = mockk<CommentService>(relaxed = true)
+            val components = mockk<ControllerComponents>(relaxed = true)
+            val request = mockk<HttpServletRequest>(relaxed = true)
 
-        val article = Article.Empty.copy(courseId = null, slug = "p-slug", draft = false)
-        every { request.requestURI } returns "/p-slug"
-        every { articleService.findBySlugPublic("p-slug") } returns article
+            val article = Article.Empty.copy(courseId = null, slug = "p-slug", draft = false)
+            every { request.requestURI } returns "/p-slug"
+            every { articleService.findBySlugPublic("p-slug") } returns article
 
-        val controller = WebController(articleService, categoryService, articleCategoryRepository, productService, commentService, courseService, components, mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
-        val result = controller.article(request, "p-slug")
+            val controller =
+                WebController(
+                    articleService,
+                    categoryService,
+                    articleCategoryRepository,
+                    productService,
+                    commentService,
+                    courseService,
+                    components,
+                    mockk(relaxed = true),
+                    mockk(relaxed = true),
+                    mockk(relaxed = true)
+                )
+            val result = controller.article(request, "p-slug")
 
-        // should have invoked public lookup
-        verify { articleService.findBySlugPublic("p-slug") }
-        // course service must not be invoked for public path
-        verify(exactly = 0) { courseService.findCoursesForUser(any()) }
-    }
+            // should have invoked public lookup
+            verify { articleService.findBySlugPublic("p-slug") }
+            // course service must not be invoked for public path
+            verify(exactly = 0) { courseService.findCoursesForUser(any()) }
+        }
 
-})
+    })


### PR DESCRIPTION
Fixes #113

## Evaluation (read-only grade)

✅ Acceptance-criteria grade 100% — meets the 70% bar (iteration 1 of 2).

## Code review

✅ No actionable review findings remained after iteration 1.

---
Automation details:
- Branch: issue-113-add-member-facing-article-alias-route-an-531256
- Diff stat:

```
.autoworker/cost/issue-113.json                    | 13 ++++
 .../kotlin/org/xbery/artbeams/web/WebController.kt | 43 +++++++++---
 .../artbeams/web/WebControllerArticleAliasTest.kt  | 81 ++++++++++++++++++++++
 3 files changed, 126 insertions(+), 11 deletions(-)
```