### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782139877251.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782139877251.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782139877251",
+  "planning": {
+    "input": 77879,
+    "cached_input": 1150720,
+    "cache_write": 0,
+    "output": 4615,
+    "reasoning": 2496,
+    "cost": 0.06246,
+    "updated_at": "2026-06-22T14:54:00.536Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,9 +83,7 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-Implement article-detail member alias mapping `/a/{slug}` in WebController
-
-Rationale: member templates (src/main/resources/templates/member/courses/detail.ftl and module.ftl) link articles as `/a/${a.slug}` but the public article controller only handles `/{slug}` and uses ArticleService.findBySlugPublic. Add an alias route and member-access logic so course-bound articles are reachable from member pages while still enforcing course-product access.
+Implement persistent ModuleRepository and ModuleMapper (course modules persisted and loaded)
 
 ## Later / ideas
 


### PR DESCRIPTION
## Planning run
_Reconciled: Input Next up item '/a/{slug}' was already open (#116) so it was removed from Next up. Picked: implement persistent ModuleRepository because sprint-state.json indicates ModuleRepository is a stub and created modules are not persisted/listed, which directly blocks the 'Access to Course ... nested article details' success condition. Skipped: the '/a/{slug}' alias because it is already in-flight. Risks: changing repository wiring touches JOOQ types (CourseModules); ensure imports use generated jOOQ classes (CourseModules, CourseModulesRecord)._
**Stuck/state snapshot:** 1 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Implement persistent ModuleRepository and ModuleMapper (course modules persisted and loaded)** (estimate: M)

   Implement persistent ModuleRepository and ModuleMapper so Course modules are stored and loaded
   
   Context: src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt, src/main/kotlin/org/xbery/artbeams/courses/repository/mapper/ModuleMapper.kt, src/main/jooqGenerated/org/xbery/artbeams/jooq/schema/tables/CourseModules.kt, src/main/kotlin/org/xbery/artbeams/courses/domain/Module.kt, src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt
   
   ## Acceptance Criteria
   
   1. ModuleMapper implementation exists at src/main/kotlin/org/xbery/artbeams/courses/repository/mapper/ModuleMapper.kt and is a Spring @Component implementing org.jooq.RecordMapper<CourseModulesRecord, Module>. It maps CourseModulesRecord.id,title,image,shortDescription,perex to the Module data class fields (id, title, image, shortDescription, perex).
   2. ModuleRepository implementation exists at src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt and no longer returns an empty list. Its findByCourseId(courseId: String) method uses the jOOQ CourseModules table (org.xbery.artbeams.jooq.schema.tables.CourseModules.COURSE_MODULES) and the injected ModuleMapper to fetch modules for the given course id, ordered by SORT_ORDER.
   3. CourseRepository.findById(id) and findAll() (src/main/kotlin/org/xbery/artbeams/courses/repository/CourseRepository.kt) continue to call moduleRepository.findByCourseId(...) to populate Course.modules (no TODOs or stubs left behind).
   4. No remaining stub implementation for ModuleRepository is present (no method that trivially returns emptyList()). The files modified are consistent (ModuleRepository is declared as @Repository and ModuleMapper as @Component) so Spring can inject them.
   5. Module-related jOOQ types are referenced directly (CourseModules and CourseModulesRecord), not redefined locally; the code imports org.xbery.artbeams.jooq.schema.tables.CourseModules and org.xbery.artbeams.jooq.schema.tables.records.CourseModulesRecord.
   
   @worker
   
   Scope: M
   
   
   ---
   _Grade: 5/5 | Covers: Administration of Courses is implemented, allowing administrators to create and manage Courses (sets of articles) and assign them to products, create list of modules within this course - each module with image, title, short description and perex content (introduction text). | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._