### PR TITLE
courses: persist Course modules with ModuleRepository and ModuleMapper

### DIFF
--- a/.autoworker/cost/issue-119.json
+++ b/.autoworker/cost/issue-119.json
@@ -1,0 +1,13 @@
+{
+  "issue": 119,
+  "implementation": {
+    "input": 129658,
+    "cached_input": 1175552,
+    "cache_write": 0,
+    "output": 9506,
+    "reasoning": 4672,
+    "cost": 0.090159,
+    "updated_at": "2026-06-22T15:06:34.417Z"
+  },
+  "review": null
+}

--- a/src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt
@@ -1,16 +1,25 @@
 package org.xbery.artbeams.courses.repository
 
+import org.jooq.DSLContext
 import org.springframework.stereotype.Repository
 import org.xbery.artbeams.courses.domain.Module
+import org.xbery.artbeams.courses.repository.mapper.ModuleMapper
+import org.xbery.artbeams.jooq.schema.tables.CourseModules
 
 /**
- * Minimal Module repository used by ModuleService.
- *
- * Note: This is a simple stub repository. Once DB migrations and jOOQ mappings
- * are available this implementation should be replaced with a proper JOOQ-based
- * repository that reads course_modules table.
+ * JOOQ-based Module repository that loads modules for a given course.
  */
 @Repository
-class ModuleRepository {
-    fun findByCourseId(courseId: String): List<Module> = emptyList()
+class ModuleRepository(
+    private val dsl: DSLContext,
+    private val mapper: ModuleMapper
+) {
+    /**
+     * Fetch modules belonging to the specified course, ordered by sort order.
+     */
+    fun findByCourseId(courseId: String): List<Module> = dsl
+        .selectFrom(CourseModules.COURSE_MODULES)
+        .where(CourseModules.COURSE_MODULES.COURSE_ID.eq(courseId))
+        .orderBy(CourseModules.COURSE_MODULES.SORT_ORDER)
+        .fetch(mapper)
 }

--- a/src/main/kotlin/org/xbery/artbeams/courses/repository/mapper/ModuleMapper.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/repository/mapper/ModuleMapper.kt
@@ -1,0 +1,20 @@
+package org.xbery.artbeams.courses.repository.mapper
+
+import org.jooq.RecordMapper
+import org.springframework.stereotype.Component
+import org.xbery.artbeams.courses.domain.Module
+import org.xbery.artbeams.jooq.schema.tables.records.CourseModulesRecord
+
+/**
+ * Maps jOOQ CourseModulesRecord to domain Module.
+ */
+@Component
+class ModuleMapper : RecordMapper<CourseModulesRecord, Module> {
+    override fun map(record: CourseModulesRecord): Module = Module(
+        id = requireNotNull(record.id),
+        title = requireNotNull(record.title),
+        image = record.image,
+        shortDescription = record.shortDescription,
+        perex = record.perex
+    )
+}

--- a/src/main/kotlin/org/xbery/artbeams/courses/repository/mapper/ModuleMapper.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/repository/mapper/ModuleMapper.kt
@@ -11,8 +11,14 @@ import org.xbery.artbeams.jooq.schema.tables.records.CourseModulesRecord
 @Component
 class ModuleMapper : RecordMapper<CourseModulesRecord, Module> {
     override fun map(record: CourseModulesRecord): Module = Module(
-        id = requireNotNull(record.id),
-        title = requireNotNull(record.title),
+        // id is expected to be present for persisted records; keep requireNotNull to
+        // fail fast with a clear message if DB contains an invalid row.
+        id = requireNotNull(record.id) { "CourseModulesRecord.id is null" },
+        // TITLE column in the jOOQ stub is nullable (DB may allow null title). Map
+        // a safe default to avoid runtime exceptions during read. The admin/service
+        // layers validate title on write, so an empty string here represents missing
+        // data rather than causing a crash.
+        title = record.title ?: "",
         image = record.image,
         shortDescription = record.shortDescription,
         perex = record.perex


### PR DESCRIPTION
Fixes #119

## Evaluation (read-only grade)

✅ Acceptance-criteria grade 100% — meets the 70% bar (iteration 2 of 2).

## Code review

✅ No actionable review findings remained after iteration 2.

---
Automation details:
- Branch: issue-119-implement-persistent-modulerepository-an-6fd687
- Diff stat:

```
.autoworker/cost/issue-119.json                    | 13 +++++++++++
 .../courses/repository/ModuleRepository.kt         | 23 +++++++++++++------
 .../courses/repository/mapper/ModuleMapper.kt      | 26 ++++++++++++++++++++++
 3 files changed, 55 insertions(+), 7 deletions(-)
```