### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782144001476.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782144001476.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782144001476",
+  "planning": {
+    "input": 63951,
+    "cached_input": 292224,
+    "cache_write": 0,
+    "output": 2626,
+    "reasoning": 2432,
+    "cost": 0.033409,
+    "updated_at": "2026-06-22T16:02:08.338Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,23 +83,10 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-_(none yet)_
+Investigate and reconcile member-facing article detail and sprint-state verifier mismatch
+
+Rationale: verifier reports ModuleRepository is a stub and /a/{slug} alias mapping is missing while recent commits implemented ModuleRepository and WebController mapping. Audit the listed files, produce a short diagnostic report and apply minimal fixes or test updates so the verifier's expectations align with code.
 
 ## Later / ideas
 
-Investigate and reconcile member-facing article detail and sprint-state verifier mismatch
-
-Rationale: the repository contains working implementations of ModuleRepository (src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt)
-and ModuleMapper (src/main/kotlin/org/xbery/artbeams/courses/repository/mapper/ModuleMapper.kt) as well as WebController article alias handling (src/main/kotlin/org/xbery/artbeams/web/WebController.kt).
-The verifier still reports unresolved failures (modules not persisted; missing /a/{slug} mapping). Add an investigation task to audit the following files and tests to determine why the verifier still flags the sprint as "needs_fixes":
-
-- src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt
-- src/main/kotlin/org/xbery/artbeams/courses/repository/mapper/ModuleMapper.kt
-- src/main/kotlin/org/xbery/artbeams/web/WebController.kt
-- src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt
-- src/main/resources/templates/member/courses/module.ftl (template presence and links)
-- src/main/resources/templates/article.ftl (article detail template and expected model keys)
-- src/test/kotlin/org/xbery/artbeams/courses/CourseRepositoryModulesTest.kt
-- src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerAccessTest.kt
-
-This is a research/investigation task (Later) and not yet ready for implementation.
+_(none yet)_


### PR DESCRIPTION
## Planning run
_Reconciled: the Later item that audits why the verifier flags missing module persistence and article alias mapping is promoted to Next up because failure conditions take priority and the codebase shows recent related commits. Picked: a single focused investigation issue that produces a diagnostic report and applies small, safe fixes, because this is the lowest-risk path to clear the verifier. Skipped: adding direct fixes without an audit (would risk duplicating open work #116). Risks: the verifier may be out-of-date; the audit must clearly state whether fixes are needed or the verifier should be updated._
**Stuck/state snapshot:** 1 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Investigate and reconcile member-facing article detail and sprint-state verifier mismatch** (estimate: M)

   Investigate why the sprint verifier still flags course modules and article alias as missing, produce a diagnostic report and apply minimal fixes.
   
   Context: review and reconcile the implementation in the following files:
   - src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt
   - src/main/kotlin/org/xbery/artbeams/courses/repository/mapper/ModuleMapper.kt
   - src/main/kotlin/org/xbery/artbeams/web/WebController.kt
   - src/main/kotlin/org/xbery/artbeams/courses/controller/CourseController.kt
   - src/main/resources/templates/member/courses/module.ftl
   - src/main/resources/templates/article.ftl
   - src/test/kotlin/org/xbery/artbeams/courses/CourseRepositoryModulesTest.kt
   - src/test/kotlin/org/xbery/artbeams/courses/controller/CourseControllerAccessTest.kt
   
   ## Acceptance Criteria
   
   1. An audit file .autoworker/course-member-verifier-audit.md is added that lists for each of the files above whether the code matches the sprint verifier expectations, and, for any mismatch, the concrete root cause and proposed small fixes (file paths and code locations must be referenced). The grader can verify the file exists and contains the listed file paths.
   
   2. ModuleRepository implementation is not a stub: src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt must not contain a trivial stub returning an empty list or TODO; the file must reference ModuleMapper (class name) or perform a JOOQ fetch. The grader will verify by reading the file for absence of the tokens "return emptyList()" or "TODO" and presence of "ModuleMapper" or ".fetch(".
   
   3. WebController must include the article alias mapping for "/a/{slug}" and the alias path access checks: src/main/kotlin/org/xbery/artbeams/web/WebController.kt should contain a @GetMapping that includes "/a/{slug}" and the article(...) method must perform the course-access checks (verify presence of code that reads request.requestURI.startsWith("/a/") and checks article.courseId with courseService.findCoursesForUser). The grader will verify by reading the method body for these tokens.
   
   4. Tests that expect modules to be populated exist: src/test/kotlin/org/xbery/artbeams/courses/CourseRepositoryModulesTest.kt must be present and reference ModuleRepository in its test setup (verify the file contains the import or usage of ModuleRepository). If the audit finds the tests are out-of-date relative to code changes, update the test to match the current API (only minimal, compile-time-safe edits). The grader will verify presence and that the test imports ModuleRepository.
   
   5. If any minimal, safe code fixes are applied, they must not introduce TODOs or commented-out verification skips; changes must be limited to the files listed in Context and/or the two test files above. The grader will verify by reading diffs.
   
   @worker
   
   Scope: M
   
   
   ---
   _Grade: 5/5 | Covers: - Access to Course works when member user logs into member section, and can see menu with available Courses, visit their details up to nested article details. | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._