### PR TITLE
Persist and delete Course Modules (admin CRUD)

### DIFF
--- a/.autoworker/cost/issue-126.json
+++ b/.autoworker/cost/issue-126.json
@@ -1,0 +1,13 @@
+{
+  "issue": 126,
+  "implementation": {
+    "input": 129557,
+    "cached_input": 1246080,
+    "cache_write": 0,
+    "output": 14183,
+    "reasoning": 7680,
+    "cost": 0.107267,
+    "updated_at": "2026-06-23T06:18:00.805Z"
+  },
+  "review": null
+}

--- a/.autoworker/cost/issue-126.json
+++ b/.autoworker/cost/issue-126.json
@@ -9,5 +9,13 @@
     "cost": 0.107267,
     "updated_at": "2026-06-23T06:18:00.805Z"
   },
-  "review": null
+  "review": {
+    "input": 36862,
+    "cached_input": 435072,
+    "cache_write": 0,
+    "output": 2036,
+    "reasoning": 1024,
+    "cost": 0.026212,
+    "updated_at": "2026-06-23T06:24:57.367Z"
+  }
 }

--- a/src/main/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminController.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminController.kt
@@ -59,7 +59,11 @@ class ModuleAdminController(
 
     @PostMapping("/delete")
     fun delete(@PathVariable courseId: String, request: HttpServletRequest): Any {
-        // No-op for stub repository
+        // Read module id from request parameters. Accept both 'id' and 'module.id'
+        val id = request.getParameter("id") ?: request.getParameter("module.id")
+        if (id.isNullOrBlank()) return notFound(request)
+
+        moduleService.deleteModule(courseId, id)
         return redirect("/admin/courses/$courseId/modules")
     }
 

--- a/src/main/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminController.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminController.kt
@@ -34,7 +34,9 @@ class ModuleAdminController(
 
     @GetMapping(value = ["/{id}/edit"], produces = [MediaType.TEXT_HTML_VALUE])
     fun editForm(@PathVariable courseId: String, request: HttpServletRequest, @PathVariable id: String?): Any {
-        val edited = if (id == null) EditedModule("0", "", null, null, null) else EditedModule(id, "", null, null, null)
+        // For new modules use null id instead of sentinel "0" so repository
+        // can reliably detect new entities. EditedModule.id is nullable.
+        val edited = if (id == null) EditedModule(null, "", null, null, null) else EditedModule(id, "", null, null, null)
         return renderEditForm(request, courseId, edited, ValidationResult.empty, null)
     }
 

--- a/src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository
 import org.xbery.artbeams.courses.domain.Module
 import org.xbery.artbeams.courses.repository.mapper.ModuleMapper
 import org.xbery.artbeams.jooq.schema.tables.CourseModules
+import java.util.UUID
 
 /**
  * JOOQ-based Module repository that loads modules for a given course.
@@ -22,4 +23,47 @@ class ModuleRepository(
         .where(CourseModules.COURSE_MODULES.COURSE_ID.eq(courseId))
         .orderBy(CourseModules.COURSE_MODULES.SORT_ORDER)
         .fetch(mapper)
+
+    /**
+     * Persist a module for a course. If edited.id is blank a new id is generated.
+     * The method sets a SORT_ORDER value (append to end) and returns persisted
+     * Module mapped from the returned record.
+     */
+    fun save(courseId: String, edited: org.xbery.artbeams.courses.admin.EditedModule): Module? {
+        val id = edited.id?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
+
+        // Compute next sort order as count of existing modules + 1
+        val count = dsl
+            .selectCount()
+            .from(CourseModules.COURSE_MODULES)
+            .where(CourseModules.COURSE_MODULES.COURSE_ID.eq(courseId))
+            .fetchOne(0, Long::class.java) ?: 0L
+        val sortOrder = count.toInt() + 1
+
+        val record = dsl
+            .insertInto(CourseModules.COURSE_MODULES)
+            .set(CourseModules.COURSE_MODULES.ID, id)
+            .set(CourseModules.COURSE_MODULES.COURSE_ID, courseId)
+            .set(CourseModules.COURSE_MODULES.TITLE, edited.title)
+            .set(CourseModules.COURSE_MODULES.IMAGE, edited.image)
+            .set(CourseModules.COURSE_MODULES.SHORT_DESCRIPTION, edited.shortDescription)
+            .set(CourseModules.COURSE_MODULES.PEREX, edited.perex)
+            .set(CourseModules.COURSE_MODULES.SORT_ORDER, sortOrder)
+            .returning()
+            .fetchOne()
+
+        return record?.let { mapper.map(it) }
+    }
+
+    /**
+     * Delete a module constrained by both id and courseId to avoid accidental
+     * deletion of modules belonging to another course.
+     */
+    fun delete(courseId: String, id: String) {
+        dsl
+            .deleteFrom(CourseModules.COURSE_MODULES)
+            .where(CourseModules.COURSE_MODULES.ID.eq(id))
+            .and(CourseModules.COURSE_MODULES.COURSE_ID.eq(courseId))
+            .execute()
+    }
 }

--- a/src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt
@@ -2,6 +2,8 @@ package org.xbery.artbeams.courses.repository
 
 import org.jooq.DSLContext
 import org.springframework.stereotype.Repository
+import org.jooq.Record
+import org.jooq.impl.DSL
 import org.xbery.artbeams.courses.domain.Module
 import org.xbery.artbeams.courses.repository.mapper.ModuleMapper
 import org.xbery.artbeams.jooq.schema.tables.CourseModules
@@ -32,13 +34,40 @@ class ModuleRepository(
     fun save(courseId: String, edited: org.xbery.artbeams.courses.admin.EditedModule): Module? {
         val id = edited.id?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
 
-        // Compute next sort order as count of existing modules + 1
-        val count = dsl
-            .selectCount()
+        // First try to find existing module by id + courseId. If present perform
+        // UPDATE preserving existing sort order. Otherwise INSERT a new row and
+        // compute SORT_ORDER as (MAX + 1) for the course.
+        val existing: Record? = dsl
+            .selectFrom(CourseModules.COURSE_MODULES)
+            .where(CourseModules.COURSE_MODULES.ID.eq(id))
+            .and(CourseModules.COURSE_MODULES.COURSE_ID.eq(courseId))
+            .fetchOne()
+
+        if (existing != null) {
+            val updated = dsl
+                .update(CourseModules.COURSE_MODULES)
+                .set(CourseModules.COURSE_MODULES.TITLE, edited.title)
+                .set(CourseModules.COURSE_MODULES.IMAGE, edited.image)
+                .set(CourseModules.COURSE_MODULES.SHORT_DESCRIPTION, edited.shortDescription)
+                .set(CourseModules.COURSE_MODULES.PEREX, edited.perex)
+                // preserve SORT_ORDER from existing record
+                .where(CourseModules.COURSE_MODULES.ID.eq(id))
+                .and(CourseModules.COURSE_MODULES.COURSE_ID.eq(courseId))
+                .returning()
+                .fetchOne()
+
+            return updated?.let { mapper.map(it) }
+        }
+
+        // No existing module - compute next sort order using MAX(SORT_ORDER).
+        // This is executed in the same transactional context as caller should
+        // ensure (@Transactional on service) to avoid race conditions.
+        val maxOrder = dsl
+            .select(DSL.max(CourseModules.COURSE_MODULES.SORT_ORDER))
             .from(CourseModules.COURSE_MODULES)
             .where(CourseModules.COURSE_MODULES.COURSE_ID.eq(courseId))
-            .fetchOne(0, Long::class.java) ?: 0L
-        val sortOrder = count.toInt() + 1
+            .fetchOne(0, Int::class.java) ?: 0
+        val sortOrder = maxOrder + 1
 
         val record = dsl
             .insertInto(CourseModules.COURSE_MODULES)

--- a/src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt
@@ -1,9 +1,9 @@
 package org.xbery.artbeams.courses.repository
 
 import org.jooq.DSLContext
-import org.springframework.stereotype.Repository
 import org.jooq.Record
 import org.jooq.impl.DSL
+import org.springframework.stereotype.Repository
 import org.xbery.artbeams.courses.domain.Module
 import org.xbery.artbeams.courses.repository.mapper.ModuleMapper
 import org.xbery.artbeams.jooq.schema.tables.CourseModules

--- a/src/main/kotlin/org/xbery/artbeams/courses/service/ModuleService.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/service/ModuleService.kt
@@ -13,4 +13,10 @@ interface ModuleService {
      * may later delegate to repository save methods once persistence is added.
      */
     fun saveModule(courseId: String, edited: EditedModule): Module?
+
+    /**
+     * Delete module with given id belonging to a course. Implementations should
+     * enforce course ownership to avoid accidental cross-course deletion.
+     */
+    fun deleteModule(courseId: String, id: String)
 }

--- a/src/main/kotlin/org/xbery/artbeams/courses/service/ModuleServiceImpl.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/service/ModuleServiceImpl.kt
@@ -12,9 +12,11 @@ class ModuleServiceImpl(
     override fun findModulesByCourseId(courseId: String) = moduleRepository.findByCourseId(courseId)
 
     override fun saveModule(courseId: String, edited: EditedModule): Module? {
-        // Stub implementation: repository save not implemented yet. Return
-        // a domain Module instance constructed from edited data so callers
-        // (and unit tests) can verify behaviour without a DB.
-        return Module(edited.id ?: "", edited.title ?: "", edited.image, edited.shortDescription, edited.perex)
+        // Delegate to repository which performs persistence using jOOQ.
+        return moduleRepository.save(courseId, edited)
+    }
+
+    override fun deleteModule(courseId: String, id: String) {
+        moduleRepository.delete(courseId, id)
     }
 }

--- a/src/main/kotlin/org/xbery/artbeams/courses/service/ModuleServiceImpl.kt
+++ b/src/main/kotlin/org/xbery/artbeams/courses/service/ModuleServiceImpl.kt
@@ -1,6 +1,7 @@
 package org.xbery.artbeams.courses.service
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.xbery.artbeams.courses.admin.EditedModule
 import org.xbery.artbeams.courses.domain.Module
 import org.xbery.artbeams.courses.repository.ModuleRepository
@@ -11,8 +12,13 @@ class ModuleServiceImpl(
 ) : ModuleService {
     override fun findModulesByCourseId(courseId: String) = moduleRepository.findByCourseId(courseId)
 
+    @Transactional
     override fun saveModule(courseId: String, edited: EditedModule): Module? {
-        // Delegate to repository which performs persistence using jOOQ.
+        // Execute save inside a transaction to ensure atomicity of multi-
+        // statement operations (compute max sort order + insert) and to
+        // reduce race conditions when multiple modules are created
+        // concurrently. The repository itself performs either UPDATE or
+        // INSERT depending on existence.
         return moduleRepository.save(courseId, edited)
     }
 


### PR DESCRIPTION
Fixes #126

## Evaluation (read-only grade)

✅ Acceptance-criteria grade 100% — meets the 70% bar (iteration 2 of 2).

## Code review

⚠️ Actionable review findings remained after 2 iteration(s):
- [critical/correctness] Sentinel id '0' is treated as a real id and may be persisted: ModuleAdminController creates a new EditedModule with id = "0" (src/main/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminController.kt:37). ModuleForm binds this hidden id (ModuleForm.definition: field "id"). ModuleRepository.save uses edited.id?.takeIf { it.isNotBlank() } to decide whether to generate a new UUID (src/main/kotlin/org/xbery/artbeams/courses/repository/ModuleRepository.kt:34-36). Because "0" is not blank, the repository will treat it as an existing id and will INSERT a row with ID = "0" when no existing row is found. That allows multiple new modules to be inserted with the same id "0", causing primary-key conflicts, or to create unexpected persisted sentinel ids. Fix: treat the conventional sentinel value as empty, i.e. treat blank OR equals("0") as a new id. Options: (a) change ModuleAdminController to initialize EditedModule.id as null or empty string for new entities; or (b) change ModuleRepository.save to compute val id = edited.id?.takeIf { it.isNotBlank() && it != "0" } ?: UUID.randomUUID().toString(). Update tests accordingly.

---
Automation details:
- Branch: issue-126-persist-and-delete-course-modules-admin--ef8a9e
- Diff stat:

```
.autoworker/cost/issue-126.json                    | 13 ++++
 .../courses/admin/ModuleAdminController.kt         |  6 +-
 .../courses/repository/ModuleRepository.kt         | 73 ++++++++++++++++++++++
 .../artbeams/courses/service/ModuleService.kt      |  6 ++
 .../artbeams/courses/service/ModuleServiceImpl.kt  | 16 +++--
 5 files changed, 109 insertions(+), 5 deletions(-)
```