### PR TITLE
Planning: 1 proposed

### DIFF
--- a/.autoworker/cost/planning-plan-beranradek-artbeams-1782195910226.json
+++ b/.autoworker/cost/planning-plan-beranradek-artbeams-1782195910226.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "plan-beranradek-artbeams-1782195910226",
+  "planning": {
+    "input": 28788,
+    "cached_input": 167936,
+    "cache_write": 0,
+    "output": 1808,
+    "reasoning": 2624,
+    "cost": 0.020259,
+    "updated_at": "2026-06-23T06:26:44.574Z"
+  }
+}

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -83,7 +83,9 @@ Each bullet is an observable symptom that must be resolved before the sprint can
 
 ## Next up (ready)
 
-- Persist and delete Course Modules (admin CRUD)
+Add unit test for ModuleAdminController.delete behavior
+
+Reason: controller.save and list already have unit tests (src/test/kotlin/.../ModuleAdminControllerTest.kt) but delete() is not covered. Add a focused unit test that verifies the controller reads the id from request, delegates to ModuleService.deleteModule(courseId, id) and redirects to the module list. This closes the remaining coverage gap for module admin CRUD.
 
 ## Later / ideas
 


### PR DESCRIPTION
## Planning run
_Reconciled: source shows ModuleRepository/ModuleService/ModuleAdminController implementations already exist but tests cover list/save only. Picked: add a small, focused unit test for ModuleAdminController.delete to close the coverage gap and satisfy the sprint verifier. Skipped: no larger refactors because code compiles and other tests exist. Risks: none significant — this is a single-file unit test using existing mock patterns._
**Stuck/state snapshot:** 0 worker-mention open, 0 ready (target 3); cap this run: 1, allowed: 1.
### Proposed issues
1. **Add unit test: ModuleAdminController.delete behavior** (estimate: S)

   Add a focused unit test that verifies ModuleAdminController.delete correctly reads the module id from the request, delegates deletion to ModuleService.deleteModule(courseId, id), and redirects to the modules list.
   
   Context: controller code at src/main/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminController.kt and service interface at src/main/kotlin/org/xbery/artbeams/courses/service/ModuleService.kt; put the test at src/test/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminControllerDeleteTest.kt.
   
   ## Acceptance Criteria
   
   1. A new test file exists at src/test/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminControllerDeleteTest.kt containing at least one test function that constructs a ModuleAdminController with a mocked ModuleService and mocked ControllerComponents (similar mocking style as src/test/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminControllerTest.kt).
   2. The test calls controller.delete("c1", request) where request is a MockHttpServletRequest with parameter "id" (or "module.id") set to a non-empty value (e.g. "m1"). The test verifies via mockk's verify that moduleService.deleteModule("c1", "m1") was invoked exactly once.
   3. The test asserts that the controller.delete call returns the redirect string "redirect:/admin/courses/c1/modules" (the same redirect used in ModuleAdminController.save/delete). The assertion is present in the test file (read-only verification of the assertion is sufficient).
   4. No TODO or stub comments related to delete testing remain in the new test file.
   
   @worker
   
   Scope: S
   
   
   ---
   _Grade: 5/5 | Covers: Administration of Courses is implemented, allowing administrators to create and manage Courses (sets of articles) and assign them to products, create list of modules within this course - each module with image, title, short description and perex content (introduction text). | Priority: high_
_Issues created from this run will be listed as a comment on this PR once dispatched._