### PR TITLE
Add unit test for ModuleAdminController.delete

### DIFF
--- a/.autoworker/cost/issue-129.json
+++ b/.autoworker/cost/issue-129.json
@@ -1,0 +1,13 @@
+{
+  "issue": 129,
+  "implementation": {
+    "input": 56126,
+    "cached_input": 206976,
+    "cache_write": 0,
+    "output": 2786,
+    "reasoning": 1216,
+    "cost": 0.02721,
+    "updated_at": "2026-06-23T06:31:35.535Z"
+  },
+  "review": null
+}

--- a/src/test/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminControllerDeleteTest.kt
+++ b/src/test/kotlin/org/xbery/artbeams/courses/admin/ModuleAdminControllerDeleteTest.kt
@@ -1,0 +1,40 @@
+package org.xbery.artbeams.courses.admin
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.xbery.artbeams.common.controller.ControllerComponents
+import org.xbery.artbeams.config.service.ConfigService
+import org.xbery.artbeams.courses.service.ModuleService
+import org.xbery.artbeams.localisation.repository.LocalisationRepository
+
+class ModuleAdminControllerDeleteTest {
+    @Test
+    fun `POST delete reads id and delegates then redirects`() {
+        val moduleService = mockk<ModuleService>(relaxed = true)
+        val components = mockk<ControllerComponents>(relaxed = true)
+        val locRepo = mockk<LocalisationRepository>(relaxed = true)
+        val cfg = mockk<ConfigService>(relaxed = true)
+        every { components.localisationRepository } returns locRepo
+        every { locRepo.getEntries() } returns emptyMap()
+        every { components.getLoggedUser(any()) } returns null
+        every { components.configService } returns cfg
+
+        val controller = ModuleAdminController(moduleService, components)
+
+        val request = MockHttpServletRequest()
+        // Controller accepts both 'id' and 'module.id' - use 'id' here
+        request.setParameter("id", "m1")
+
+        val result = controller.delete("c1", request)
+
+        // verify delegation to service
+        verify(exactly = 1) { moduleService.deleteModule("c1", "m1") }
+
+        // verify redirect target
+        Assertions.assertEquals("redirect:/admin/courses/c1/modules", result)
+    }
+}


### PR DESCRIPTION
Fixes #129

## Evaluation (read-only grade)

✅ Acceptance-criteria grade 100% — meets the 70% bar (iteration 1 of 2).

## Code review

✅ No actionable review findings remained after iteration 1.

---
Automation details:
- Branch: issue-129-add-unit-test-moduleadmincontroller.dele-f9957f
- Diff stat:

```
.autoworker/cost/issue-129.json                    | 13 +++++++
 .../admin/ModuleAdminControllerDeleteTest.kt       | 40 ++++++++++++++++++++++
 2 files changed, 53 insertions(+)
```